### PR TITLE
Bug fix for `foo.bar[0].foo` that is not working.

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -131,7 +131,10 @@ var Scope = {
         }
       } else if (str[i] === '.') {
         // foo.bar
-        seq.push(name)
+        // foo.bar[0].foo
+        // In the case of foo.bar[0].foo, must check length because
+        // name will be empty after the closing `]` is handled above.
+        if (name.length) seq.push(name)
         name = ''
       } else {
         // foo.bar


### PR DESCRIPTION
Corrects a bug where `foo.bar[0].foo` results in error: 'Cannot read property `foo` of undefined', because the sequence contains an empty string; i.e., `seq.push('')` should be avoided.

Another possible solution would be to strip empty strings from the final `seq` variable, but this PR fixes the immediate problem.