### PR TITLE
Ignore "fs" module in browser environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "dependencies": {
     "any-promise": "^1.3.0"
   },
+  "browser": {
+    "fs": false
+  },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",
     "babelify": "^7.3.0",


### PR DESCRIPTION
Depending on this package causes an error in Webpack and other similar browser-side module bundlers as the Node.js core modules are not available. This change simply tells the bundler to ignore the fs package in browser environments.