### PR TITLE
Fix `name` variable type change

### DIFF
--- a/src/lexical.js
+++ b/src/lexical.js
@@ -9,7 +9,7 @@ var integer = /-?\d+/
 var number = /-?\d+\.?\d*|\.?\d+/
 var bool = /true|false/
 
-// peoperty access
+// property access
 var identifier = /[\w-]+[?]?/
 var subscript = new RegExp(`\\[(?:${quoted.source}|[\\w-\\.]+)\\]`)
 var literal = new RegExp(`(?:${quoted.source}|${bool.source}|${number.source})`)

--- a/src/scope.js
+++ b/src/scope.js
@@ -110,7 +110,7 @@ var Scope = {
             assert(j !== -1, `unbalanced []: ${str}`)
             name = str.slice(i + 1, j)
             if (!lexical.isInteger(name)) { // foo[bar] vs. foo[1]
-              name = this.get(name).toString()
+              name = (this.get(name) ? this.get(name) : '').toString()
             }
             push()
             i = j + 1

--- a/src/scope.js
+++ b/src/scope.js
@@ -110,7 +110,7 @@ var Scope = {
             assert(j !== -1, `unbalanced []: ${str}`)
             name = str.slice(i + 1, j)
             if (!lexical.isInteger(name)) { // foo[bar] vs. foo[1]
-              name = this.get(name)
+              name = this.get(name).toString()
             }
             push()
             i = j + 1


### PR DESCRIPTION
`name` should be a string. However, `this.get(name)` will return an integer, which is later assigned to `name`. Hereby, it will fail at `if (name.length)` in `push ()`.