### PR TITLE
perf: improve getTemplate() when cache is enabled

### DIFF
--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,11 +1,13 @@
 import output from './output'
 import tag from './tag'
 import demo from './demo'
+import layout from './layout'
 
 async function main () {
   await output()
   await tag()
   await demo()
+  await layout()
 }
 
 main()

--- a/benchmark/layout.ts
+++ b/benchmark/layout.ts
@@ -1,0 +1,36 @@
+import * as Benchmark from 'benchmark'
+import Liquid from '../src/liquid'
+
+const engineOptions = {
+  root: __dirname,
+  extname: '.liquid'
+}
+
+const engine = new Liquid(engineOptions)
+const cachingEngine = new Liquid({
+  ...engineOptions,
+  cache: true
+})
+
+const template = `
+{% layout "./templates/layout.liquid" %}
+{% block body %}a small body{% endblock %}
+`
+
+export default function () {
+  console.log('--- layout ---')
+  return new Promise(resolve => {
+    new Benchmark.Suite('layout')
+      .add('cache=false', {
+        defer: true,
+        fn: (d: any) => engine.parseAndRender(template, {}).then(x => d.resolve(x))
+      })
+      .add('cache=true', {
+        defer: true,
+        fn: (d: any) => cachingEngine.parseAndRender(template, {}).then(x => d.resolve(x))
+      })
+      .on('cycle', (event: any) => console.log(String(event.target)))
+      .on('complete', resolve)
+      .run({ 'async': true })
+  })
+}

--- a/benchmark/templates/layout.liquid
+++ b/benchmark/templates/layout.liquid
@@ -1,0 +1,2 @@
+This is a barely empty layout with a body:
+{% block body %}{% endblock %}

--- a/src/liquid.ts
+++ b/src/liquid.ts
@@ -51,9 +51,10 @@ export default class Liquid {
     const paths = roots.map(root => fs.resolve(root, file, this.options.extname))
 
     for (const filepath of paths) {
+      if (this.options.cache && this.cache[filepath]) return this.cache[filepath]
+
       if (!(await fs.exists(filepath))) continue
 
-      if (this.options.cache && this.cache[filepath]) return this.cache[filepath]
       const value = this.parse(await fs.readFile(filepath), filepath)
       if (this.options.cache) this.cache[filepath] = value
       return value


### PR DESCRIPTION
Checking for file existence is unnecessary (and consumes IO) when cache already contains entry.

Contributed a little benchmark suite that measures the improvement:

Before:
```
--- layout ---
cache=false x 2,013 ops/sec ±12.06% (55 runs sampled)
cache=true x 4,865 ops/sec ±8.44% (67 runs sampled)
```
After:
```
--- layout ---
cache=false x 2,149 ops/sec ±11.38% (57 runs sampled)
cache=true x 7,716 ops/sec ±2.93% (70 runs sampled)
```