### PR TITLE
Expose `fs` as an option to override the default implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Otherwise, undefined variables will cause an exception. Defaults to `false`.
 
 * `greedy` is used to specify whether `trim*Left`/`trim*Right` is greedy. When set to `true`, all consecutive blank characters including `\n` will be trimed regardless of line breaks. Defaults to `true`.
 
+* `fs` is used to override the default file-system module with a custom implementation.
+
 ## Register Filters
 
 ```javascript

--- a/src/liquid-options.ts
+++ b/src/liquid-options.ts
@@ -1,4 +1,5 @@
 import * as _ from './util/underscore'
+import IFS from './fs/ifs';
 
 export interface LiquidOptions {
   /** `root` is a directory or an array of directories to resolve layouts and includes, as well as the filename passed in when calling `.renderFile()`. If an array, the files are looked up in the order they occur in the array. Defaults to `["."]` */
@@ -28,7 +29,9 @@ export interface LiquidOptions {
   outputDelimiterLeft?: string,
   outputDelimiterRight?: string,
   /** `greedy` is used to specify whether `trim*Left`/`trim*Right` is greedy. When set to `true`, all consecutive blank characters including `\n` will be trimed regardless of line breaks. Defaults to `true`. */
-  greedy?: boolean
+  greedy?: boolean,
+  /** `fs` is used to override the default file-system module with a custom implementation */
+  fs?: IFS
 }
 
 interface NormalizedOptions extends LiquidOptions {

--- a/test/integration/liquid/fs-option.ts
+++ b/test/integration/liquid/fs-option.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai'
+import Liquid from '../../../src/liquid'
+
+describe('LiquidOptions#fs', function () {
+  let engine: Liquid
+  const fs = {
+    exists: () => Promise.resolve(true),
+    readFile: () => Promise.resolve('test file content'),
+    resolve: () => 'resolved'
+  }
+  beforeEach(function () {
+    engine = new Liquid({
+      root: '/root/',
+      fs
+    })
+  })
+  it('should be used to read templates', function () {
+    return engine.renderFile('files/foo')
+      .then(x => expect(x).to.equal('test file content'))
+  })
+})


### PR DESCRIPTION
As discussed in #131 , this PR exposes a new `fs` option that allows to change how files are read from the file-system. The `fs` module is used while rendering "partials" and "includes" and also when calling `engine.renderFile()`.

The option is optional. When omitted, the engine follows the current behavior of loading via the native `fs` module (Node.js) or via an AJAX request (browser).

Overriding the `fs` option can be used for specific use cases. Examples:
- Reading partials/includes from memory (see #20).
- Preventing access to some files or directories, or blocking access to the file system altogether (see #131).

Closes #131 

Feedback appreciated 🙇 