### PR TITLE
fix: escape filter when input is undefined

### DIFF
--- a/src/builtin/filters/html.ts
+++ b/src/builtin/filters/html.ts
@@ -1,3 +1,5 @@
+import { stringify } from '../../util/underscore'
+
 const escapeMap = {
   '&': '&amp;',
   '<': '&lt;',
@@ -14,7 +16,7 @@ const unescapeMap = {
 }
 
 function escape (str: string) {
-  return str ? String(str).replace(/&|<|>|"|'/g, m => escapeMap[m]) : ''
+  return stringify(str).replace(/&|<|>|"|'/g, m => escapeMap[m])
 }
 
 function unescape (str: string) {

--- a/src/builtin/filters/html.ts
+++ b/src/builtin/filters/html.ts
@@ -14,7 +14,7 @@ const unescapeMap = {
 }
 
 function escape (str: string) {
-  return !!str ? String(str).replace(/&|<|>|"|'/g, m => escapeMap[m]) : ""
+  return str ? String(str).replace(/&|<|>|"|'/g, m => escapeMap[m]) : ''
 }
 
 function unescape (str: string) {

--- a/src/builtin/filters/html.ts
+++ b/src/builtin/filters/html.ts
@@ -14,7 +14,7 @@ const unescapeMap = {
 }
 
 function escape (str: string) {
-  return String(str).replace(/&|<|>|"|'/g, m => escapeMap[m])
+  return !!str ? String(str).replace(/&|<|>|"|'/g, m => escapeMap[m]) : ""
 }
 
 function unescape (str: string) {

--- a/test/integration/builtin/filters/html.ts
+++ b/test/integration/builtin/filters/html.ts
@@ -12,6 +12,9 @@ describe('filters/html', function () {
     it('should escape function', function () {
       return test('{{ func | escape }}', 'function () { }')
     })
+    it('should escape undefined', function () {
+      return test('{{ nonExistent.value | escape }}', '')
+    })
   })
   describe('escape_once', function () {
     it('should do escape', () =>


### PR DESCRIPTION
The built-in escape filters renders "undefined" when the input is undefined :
````javascript
// myObj does not exist
const ret = await engine.parseAndRender(`{{ myObj.someProp | escape }}`)
expect(ret).toBe("") //  Expected: "" but Received: "undefined"
````
This PR fixes it.