### PR TITLE
perf: add string flattening to reduce retained memory (node only)

### DIFF
--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -2,12 +2,14 @@ import { output } from './output'
 import { tag } from './tag'
 import { demo } from './demo'
 import { layout } from './layout'
+import { memory } from './memory'
 
 async function main () {
   await output()
   await tag()
   await demo()
   await layout()
+  await memory()
 }
 
 main()

--- a/benchmark/memory.ts
+++ b/benchmark/memory.ts
@@ -1,0 +1,32 @@
+import { join } from 'path'
+import { readFileSync } from 'fs'
+import { getHeapStatistics } from 'v8'
+import { Liquid } from '../src/liquid'
+
+const engineOptions = {
+  root: __dirname,
+  extname: '.liquid'
+}
+
+const engine = new Liquid(engineOptions)
+
+const templateString = readFileSync(join(__dirname, 'templates/lorem-html.liquid'), 'utf8')
+const templateSizeKb = templateString.length / 1024
+
+const NB_INSTANCES_TO_RETAIN = 250
+
+export function memory () {
+  console.log('--- memory ---')
+  const initialUsedHeapSize = getHeapStatistics().used_heap_size
+  const templates = []
+
+  for (let i = 0; i < NB_INSTANCES_TO_RETAIN; i++) {
+    templates.push(engine.parse(templateString))
+  }
+
+  const finalUsedHeapSize = getHeapStatistics().used_heap_size
+  const heapDifference = finalUsedHeapSize - initialUsedHeapSize
+  const avgRetainedPerTemplate = (heapDifference / NB_INSTANCES_TO_RETAIN) / 1024
+
+  console.log(`retained memory for a ${templateSizeKb}KB template: ${avgRetainedPerTemplate}KB (${NB_INSTANCES_TO_RETAIN} samples)`)
+}

--- a/benchmark/templates/lorem-html.liquid
+++ b/benchmark/templates/lorem-html.liquid
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <!-- You may use a different charset if needed -->
+
+    <title>Latin Lipsum -  Courtesy generator.lorem-ipsum.info</title>
+</head>
+
+<body>
+<p>Lorem ipsum dolor sit amet, falli detraxit facilisis sit ex. Nec vidit nihil ut, vis utamur definitionem in. Ancillae phaedrum ut eos. Ne eam errem cotidieque.
+</p>
+<p>
+    Sit amet vitae referrentur ad, oportere necessitatibus vituperatoribus vim ne. Audiam quaeque nusquam ei eos, mel ex adhuc prompta complectitur. Decore voluptua cotidieque vel ei, veri novum persecuti te sea. Nisl novum sea cu. Dicta delicatissimi ut est. Et has eripuit impedit mediocrem.
+</p>
+<p>
+    Eu vim evertitur argumentum, pro legendos iudicabit voluptatibus ne. Ne alii nullam deserunt duo, vis no animal verterem. Ne quo veniam euripidis. Pri discere mentitum vituperatoribus ne. Meliore corrumpit vim at, has ea admodum convenire.
+</p>
+<p>
+    Ne mea alii detraxit electram, his ne epicurei gloriatur consetetur. Ex pro aeque omnes appareat, possit integre accommodare eu quo. Qui in porro molestiae, no sit equidem petentium patrioque, omnes voluptaria vim te. Odio quot rebum ad sed, ei sale reque inani sea.
+</p>
+<p>
+    At mea vidit petentium, mei lorem pertinacia signiferumque ne. Per eu dicam postea probatus, sea pericula accusamus omittantur ad. Id mei munere ullamcorper. Oportere ocurreret cu vel. Pri ne dicant soluta graecis, duis ponderum corrumpit sed eu, pro ei rebum vivendum.
+</p>
+<p>
+    Eum ea exerci sententiae constituam, ut lorem putant volutpat pro. Vix ex iudicabit salutatus principes, pri nisl erat ut, ne cum persius verterem phaedrum. Vix mundi vitae eu. Vel summo vocent albucius in. Qui omnis partem possim ex, wisi doctus efficiantur cu has. Aperiri denique ea pri, cum dissentias signiferumque eu. Per posse dissentiet necessitatibus id, omnis eleifend te mel.
+</p>
+<p>
+    Phaedrum erroribus adolescens ut nec, duo mutat viris id. In tale purto dolores sit, ei consul inermis est, his ea movet expetenda. Cibo scribentur id eam, per an quem iracundia, has erat zril solet eu. Falli fierent ne cum, eam placerat facilisis suscipiantur te. Id quo dicat tractatos definiebas, est copiosae splendide id.
+</p>
+<p>
+    Constituto neglegentur qui ne, eum ne putent phaedrum, no quod nominati consulatu per. Mei cu accusam principes interesset, vim fugit abhorreant eu, ludus feugait an sed. Clita expetendis definitionem has in, meis pericula no mea, soluta nemore cotidieque eos cu. Summo populo signiferumque pri eu, eum no labores democritum posidonium, pro ignota adipisci in. Tollit molestie id mei.
+</p>
+<p>
+    Ipsum impetus et eam, ei his epicuri instructior. Impedit ullamcorper vim an. Impedit ullamcorper vim an. Et eum senserit sententiae reprimique, quem detracto sententiae at sed, no inermis ocurreret rationibus sea pericula no.
+
+</body></html>

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -71,6 +71,11 @@ const umd = {
       delimiters: ['', ''],
       './fs/node': './fs/browser'
     }),
+    replace({
+      include: './src/parser/tokenizer.ts',
+      delimiters: ['', ''],
+      './flatten/node': './flatten/browser'
+    }),
     typescript({
       tsconfigOverride: {
         include: [ 'src' ],
@@ -98,6 +103,11 @@ const min = {
       include: './src/liquid.ts',
       delimiters: ['', ''],
       './fs/node': './fs/browser'
+    }),
+    replace({
+      include: './src/parser/tokenizer.ts',
+      delimiters: ['', ''],
+      './flatten/node': './flatten/browser'
     }),
     typescript({
       tsconfigOverride: {

--- a/src/parser/flatten/browser.ts
+++ b/src/parser/flatten/browser.ts
@@ -1,0 +1,3 @@
+export function flatten (str: string) {
+  return str
+}

--- a/src/parser/flatten/node.ts
+++ b/src/parser/flatten/node.ts
@@ -1,0 +1,10 @@
+/**
+ * This function forces a string to be re-instantiated in memory using a flat representation instead of a graph
+ * of concatenated strings. This is an optimization to reduce the memory footprint of token string fragments after
+ * they are parsed.
+ * This optimization targets the V8 javascript engine and only works on Node.js.
+ * @param {string} str
+ */
+export function flatten (str: string) {
+  return Buffer.from(str).toString()
+}


### PR DESCRIPTION
## Changes
Fixes #161 

As discussed in #161, this PR applies a performance optimization to reduce the memory footprint of parsed templates that are held in memory. The implementation tries to "flatten" the string's memory representation.

After a few trials, the only implementation that works in Node 8.x, 10.x and 12.x is to convert the string to a `Buffer` instance and back to a string.

This PR also adds a memory footprint benchmark suite.

## Performance impacts

Here are the results of running the benchmarks before/after the change:

#### Node v8.16.1

**Before change**

```
--- output ---
literal x 12,549 ops/sec ±5.10% (66 runs sampled)
truncate x 16,438 ops/sec ±6.61% (66 runs sampled)
date x 16,108 ops/sec ±4.62% (69 runs sampled)
escape x 21,418 ops/sec ±4.92% (72 runs sampled)
default x 17,142 ops/sec ±6.03% (71 runs sampled)
--- tag ---
if x 15,015 ops/sec ±6.34% (65 runs sampled)
unless x 11,412 ops/sec ±21.84% (51 runs sampled)
for x 5,211 ops/sec ±10.51% (57 runs sampled)
switch x 4,201 ops/sec ±27.06% (43 runs sampled)
assign x 16,051 ops/sec ±12.60% (61 runs sampled)
capture x 21,869 ops/sec ±4.14% (71 runs sampled)
increment x 28,739 ops/sec ±10.84% (59 runs sampled)
decrement x 32,349 ops/sec ±8.22% (65 runs sampled)
tablerow x 7,899 ops/sec ±6.14% (66 runs sampled)
--- demo ---
demo x 3,117 ops/sec ±6.84% (62 runs sampled)
--- layout ---
cache=false x 2,362 ops/sec ±8.86% (62 runs sampled)
cache=true x 5,918 ops/sec ±14.59% (59 runs sampled)
--- memory ---
retained memory for a 3KB template: 130.337KB (250 samples)
```

**After change**
```
--- output ---
literal x 9,183 ops/sec ±15.14% (55 runs sampled)
truncate x 13,476 ops/sec ±10.56% (63 runs sampled)
date x 14,451 ops/sec ±5.20% (67 runs sampled)
escape x 18,873 ops/sec ±8.34% (67 runs sampled)
default x 16,910 ops/sec ±4.81% (68 runs sampled)
--- tag ---
if x 15,231 ops/sec ±3.24% (71 runs sampled)
unless x 14,695 ops/sec ±3.18% (70 runs sampled)
for x 3,768 ops/sec ±22.81% (43 runs sampled)
switch x 1,250 ops/sec ±30.12% (39 runs sampled)
assign x 14,912 ops/sec ±10.09% (60 runs sampled)
capture x 20,072 ops/sec ±5.62% (71 runs sampled)
increment x 24,952 ops/sec ±17.23% (53 runs sampled)
decrement x 26,009 ops/sec ±9.63% (58 runs sampled)
tablerow x 7,596 ops/sec ±5.29% (68 runs sampled)
--- demo ---
demo x 2,474 ops/sec ±10.26% (58 runs sampled)
--- layout ---
cache=false x 2,066 ops/sec ±11.15% (61 runs sampled)
cache=true x 6,567 ops/sec ±6.14% (68 runs sampled)
--- memory ---
retained memory for a 3KB template: 14.5260625KB (250 samples)
```

#### Node v10.16.3

**Before change**
```
--- output ---
literal x 23,165 ops/sec ±9.82% (68 runs sampled)
truncate x 27,848 ops/sec ±11.87% (59 runs sampled)
date x 28,459 ops/sec ±8.46% (66 runs sampled)
escape x 35,186 ops/sec ±11.68% (61 runs sampled)
default x 29,286 ops/sec ±11.21% (64 runs sampled)
--- tag ---
if x 24,939 ops/sec ±10.41% (60 runs sampled)
unless x 24,386 ops/sec ±10.31% (60 runs sampled)
for x 8,772 ops/sec ±15.28% (58 runs sampled)
switch x 12,475 ops/sec ±10.18% (63 runs sampled)
assign x 33,224 ops/sec ±9.23% (66 runs sampled)
capture x 36,463 ops/sec ±9.62% (64 runs sampled)
increment x 60,185 ops/sec ±12.16% (60 runs sampled)
decrement x 24,719 ops/sec ±55.25% (27 runs sampled)
tablerow x 8,308 ops/sec ±18.04% (50 runs sampled)
--- demo ---
demo x 3,494 ops/sec ±17.12% (50 runs sampled)
--- layout ---
cache=false x 2,794 ops/sec ±14.90% (55 runs sampled)
cache=true x 9,101 ops/sec ±13.30% (51 runs sampled)
--- memory ---
retained memory for a 3KB template: 98.53553125KB (250 samples)
```

**After change**
```
--- output ---
literal x 21,353 ops/sec ±9.51% (65 runs sampled)
truncate x 29,896 ops/sec ±9.59% (66 runs sampled)
date x 25,673 ops/sec ±10.01% (63 runs sampled)
escape x 35,280 ops/sec ±10.31% (65 runs sampled)
default x 30,202 ops/sec ±8.99% (65 runs sampled)
--- tag ---
if x 26,551 ops/sec ±9.17% (66 runs sampled)
unless x 25,031 ops/sec ±10.32% (65 runs sampled)
for x 9,396 ops/sec ±17.51% (65 runs sampled)
switch x 10,219 ops/sec ±13.70% (57 runs sampled)
assign x 30,277 ops/sec ±10.72% (61 runs sampled)
capture x 32,643 ops/sec ±11.43% (56 runs sampled)
increment x 59,629 ops/sec ±11.25% (63 runs sampled)
decrement x 61,304 ops/sec ±10.31% (66 runs sampled)
tablerow x 11,196 ops/sec ±10.90% (57 runs sampled)
--- demo ---
demo x 3,979 ops/sec ±12.18% (56 runs sampled)
--- layout ---
cache=false x 2,783 ops/sec ±10.69% (56 runs sampled)
cache=true x 10,978 ops/sec ±10.54% (59 runs sampled)
--- memory ---
retained memory for a 3KB template: 18.93296875KB (250 samples)
```

#### Node v12.11.1

**Before change**
```
--- output ---
literal x 18,560 ops/sec ±15.98% (61 runs sampled)
truncate x 23,535 ops/sec ±15.89% (64 runs sampled)
date x 30,289 ops/sec ±5.90% (70 runs sampled)
escape x 39,775 ops/sec ±7.63% (67 runs sampled)
default x 28,139 ops/sec ±12.73% (62 runs sampled)
--- tag ---
if x 29,444 ops/sec ±8.24% (71 runs sampled)
unless x 27,317 ops/sec ±10.17% (72 runs sampled)
for x 9,733 ops/sec ±15.09% (65 runs sampled)
switch x 11,498 ops/sec ±8.65% (64 runs sampled)
assign x 30,745 ops/sec ±7.74% (65 runs sampled)
capture x 35,279 ops/sec ±15.47% (65 runs sampled)
increment x 59,210 ops/sec ±14.25% (68 runs sampled)
decrement x 66,293 ops/sec ±9.08% (70 runs sampled)
tablerow x 12,352 ops/sec ±8.42% (69 runs sampled)
--- demo ---
demo x 4,997 ops/sec ±13.12% (67 runs sampled)
--- layout ---
cache=false x 2,772 ops/sec ±11.32% (60 runs sampled)
cache=true x 12,084 ops/sec ±12.81% (70 runs sampled)
--- memory ---
retained memory for a 3KB template: 97.79503125KB (250 samples)
```

**After change**

```
--- output ---
literal x 18,877 ops/sec ±10.26% (61 runs sampled)
truncate x 20,667 ops/sec ±22.44% (59 runs sampled)
date x 20,703 ops/sec ±17.39% (57 runs sampled)
escape x 27,398 ops/sec ±14.42% (57 runs sampled)
default x 15,843 ops/sec ±30.52% (49 runs sampled)
--- tag ---
if x 13,795 ops/sec ±18.62% (40 runs sampled)
unless x 11,405 ops/sec ±24.08% (46 runs sampled)
for x 8,654 ops/sec ±13.18% (63 runs sampled)
switch x 11,054 ops/sec ±11.63% (68 runs sampled)
assign x 29,164 ops/sec ±10.31% (63 runs sampled)
capture x 21,827 ops/sec ±23.17% (47 runs sampled)
increment x 55,947 ops/sec ±11.52% (64 runs sampled)
decrement x 52,068 ops/sec ±13.48% (59 runs sampled)
tablerow x 8,370 ops/sec ±29.84% (54 runs sampled)
--- demo ---
demo x 4,147 ops/sec ±11.10% (67 runs sampled)
--- layout ---
cache=false x 1,732 ops/sec ±17.99% (52 runs sampled)
cache=true x 9,773 ops/sec ±10.17% (63 runs sampled)
--- memory ---
retained memory for a 3KB template: 8.50384375KB (250 samples)
```

#### Summary

There seems to be a negative performance impact (ops per sec) that is most noticeable on Node.js 8.x. For 10.x and 12.x, the impact is less obvious, some tests perform better, others worse.

The memory footprint improvements are significant for the benchmarked scenario on all three versions of node.

### Potential improvements

The overhead of converting to a `Buffer` is probably more significant for smaller templates, while the potential gain on the memory side would be smaller. One idea would be to apply the flattening logic only when a given string is longer than some threshold.

One option could be to put this optimization behind an option to opt out of this behavior. For example, if a template is used and immediately trashed, there is no gain to reduce the memory footprint as it would get garbage collected quickly. On the contrary, for users that expect to call the template multiple time, the additional latency during parsing is maybe less problematic.

Thanks for sharing any feedback 🙇 
