### PR TITLE
pref: remove await/async from internal calls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "no-dupe-class-members": "off",
     "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-object-literal-type-assertion": "off",
     "@typescript-eslint/no-use-before-define": "off",

--- a/src/builtin/tags/assign.ts
+++ b/src/builtin/tags/assign.ts
@@ -11,9 +11,7 @@ export default {
     this.key = match[1]
     this.value = match[2]
   },
-  render: async function (ctx: Context) {
-    ctx.front()[this.key] = ctx.sync
-      ? this.liquid.evalValueSync(this.value, ctx)
-      : await this.liquid.evalValue(this.value, ctx)
+  render: function * (ctx: Context) {
+    ctx.front()[this.key] = yield this.liquid._evalValue(this.value, ctx)
   }
 } as ITagImplOptions

--- a/src/builtin/tags/block.ts
+++ b/src/builtin/tags/block.ts
@@ -14,16 +14,13 @@ export default {
       })
     stream.start()
   },
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
     const blocks = ctx.getRegister('blocks')
     const childDefined = blocks[this.block]
     const r = this.liquid.renderer
     const html = childDefined !== undefined
       ? childDefined
-      : (ctx.sync
-        ? r.renderTemplatesSync(this.tpls, ctx)
-        : await r.renderTemplates(this.tpls, ctx)
-      )
+      : yield r.renderTemplates(this.tpls, ctx)
 
     if (ctx.getRegister('blockMode', BlockMode.OUTPUT) === BlockMode.STORE) {
       blocks[this.block] = html

--- a/src/builtin/tags/break.ts
+++ b/src/builtin/tags/break.ts
@@ -1,7 +1,7 @@
 import { Emitter, Context, Hash } from '../../types'
 
 export default {
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function (ctx: Context, hash: Hash, emitter: Emitter) {
     emitter.break = true
   }
 }

--- a/src/builtin/tags/capture.ts
+++ b/src/builtin/tags/capture.ts
@@ -20,11 +20,9 @@ export default {
       })
     stream.start()
   },
-  render: async function (ctx: Context) {
+  render: function * (ctx: Context) {
     const r = this.liquid.renderer
-    const html = ctx.sync
-      ? r.renderTemplatesSync(this.templates, ctx)
-      : await r.renderTemplates(this.templates, ctx)
+    const html = yield r.renderTemplates(this.templates, ctx)
     ctx.front()[this.variable] = html
   }
 } as ITagImplOptions

--- a/src/builtin/tags/case.ts
+++ b/src/builtin/tags/case.ts
@@ -24,31 +24,17 @@ export default {
     stream.start()
   },
 
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
     const r = this.liquid.renderer
     for (let i = 0; i < this.cases.length; i++) {
       const branch = this.cases[i]
-      const val = await new Expression(branch.val).value(ctx)
-      const cond = await new Expression(this.cond).value(ctx)
+      const val = yield new Expression(branch.val).value(ctx)
+      const cond = yield new Expression(this.cond).value(ctx)
       if (val === cond) {
-        await r.renderTemplates(branch.templates, ctx, emitter)
+        yield r.renderTemplates(branch.templates, ctx, emitter)
         return
       }
     }
-    await r.renderTemplates(this.elseTemplates, ctx, emitter)
-  },
-
-  renderSync: function (ctx: Context, hash: Hash, emitter: Emitter) {
-    const r = this.liquid.renderer
-    for (let i = 0; i < this.cases.length; i++) {
-      const branch = this.cases[i]
-      const val = new Expression(branch.val).valueSync(ctx)
-      const cond = new Expression(this.cond).valueSync(ctx)
-      if (val === cond) {
-        r.renderTemplatesSync(branch.templates, ctx, emitter)
-        return
-      }
-    }
-    r.renderTemplatesSync(this.elseTemplates, ctx, emitter)
+    yield r.renderTemplates(this.elseTemplates, ctx, emitter)
   }
 } as ITagImplOptions

--- a/src/builtin/tags/continue.ts
+++ b/src/builtin/tags/continue.ts
@@ -1,7 +1,7 @@
 import { Emitter, Context, Hash } from '../../types'
 
 export default {
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function (ctx: Context, hash: Hash, emitter: Emitter) {
     emitter.continue = true
   }
 }

--- a/src/builtin/tags/cycle.ts
+++ b/src/builtin/tags/cycle.ts
@@ -21,10 +21,8 @@ export default {
     assert(this.candidates.length, `empty candidates: ${tagToken.raw}`)
   },
 
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
-    const group = ctx.sync
-      ? this.group.valueSync(ctx)
-      : await this.group.value(ctx)
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
+    const group = yield this.group.value(ctx)
     const fingerprint = `cycle:${group}:` + this.candidates.join(',')
     const groups = ctx.getRegister('cycle')
     let idx = groups[fingerprint]
@@ -36,9 +34,7 @@ export default {
     const candidate = this.candidates[idx]
     idx = (idx + 1) % this.candidates.length
     groups[fingerprint] = idx
-    const html = ctx.sync
-      ? new Expression(candidate).valueSync(ctx)
-      : await new Expression(candidate).value(ctx)
+    const html = yield new Expression(candidate).value(ctx)
     emitter.write(html)
   }
 } as ITagImplOptions

--- a/src/builtin/tags/for.ts
+++ b/src/builtin/tags/for.ts
@@ -36,11 +36,9 @@ export default {
 
     stream.start()
   },
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
     const r = this.liquid.renderer
-    let collection = ctx.sync
-      ? new Expression(this.collection).valueSync(ctx)
-      : await new Expression(this.collection).value(ctx)
+    let collection = yield new Expression(this.collection).value(ctx)
 
     if (!isArray(collection)) {
       if (isString(collection) && collection.length > 0) {
@@ -50,9 +48,7 @@ export default {
       }
     }
     if (!isArray(collection) || !collection.length) {
-      ctx.sync
-        ? r.renderTemplatesSync(this.elseTemplates, ctx, emitter)
-        : await r.renderTemplates(this.elseTemplates, ctx, emitter)
+      yield r.renderTemplates(this.elseTemplates, ctx, emitter)
       return
     }
 
@@ -66,9 +62,7 @@ export default {
     ctx.push(scope)
     for (const item of collection) {
       scope[this.variable] = item
-      ctx.sync
-        ? r.renderTemplatesSync(this.templates, ctx, emitter)
-        : await r.renderTemplates(this.templates, ctx, emitter)
+      yield r.renderTemplates(this.templates, ctx, emitter)
       if (emitter.break) {
         emitter.break = false
         break

--- a/src/builtin/tags/if.ts
+++ b/src/builtin/tags/if.ts
@@ -27,29 +27,16 @@ export default {
     stream.start()
   },
 
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
     const r = this.liquid.renderer
 
     for (const branch of this.branches) {
-      const cond = await new Expression(branch.cond).value(ctx)
+      const cond = yield new Expression(branch.cond).value(ctx)
       if (isTruthy(cond)) {
-        await r.renderTemplates(branch.templates, ctx, emitter)
+        yield r.renderTemplates(branch.templates, ctx, emitter)
         return
       }
     }
-    await r.renderTemplates(this.elseTemplates, ctx, emitter)
-  },
-
-  renderSync: function (ctx: Context, hash: Hash, emitter: Emitter) {
-    const r = this.liquid.renderer
-
-    for (const branch of this.branches) {
-      const cond = new Expression(branch.cond).valueSync(ctx)
-      if (isTruthy(cond)) {
-        r.renderTemplatesSync(branch.templates, ctx, emitter)
-        return
-      }
-    }
-    r.renderTemplatesSync(this.elseTemplates, ctx, emitter)
+    yield r.renderTemplates(this.elseTemplates, ctx, emitter)
   }
 } as ITagImplOptions

--- a/src/builtin/tags/layout.ts
+++ b/src/builtin/tags/layout.ts
@@ -19,12 +19,9 @@ export default {
 
     this.tpls = this.liquid.parser.parse(remainTokens)
   },
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
     const layout = ctx.opts.dynamicPartials
-      ? (ctx.sync
-        ? new Expression(this.layout).valueSync(ctx)
-        : await new Expression(this.layout).value(ctx)
-      )
+      ? yield new Expression(this.layout).value(ctx)
       : this.staticLayout
     assert(layout, `cannot apply layout with empty filename`)
 
@@ -32,20 +29,14 @@ export default {
     ctx.setRegister('blockMode', BlockMode.STORE)
     const blocks = ctx.getRegister('blocks')
     const r = this.liquid.renderer
-    const html = ctx.sync
-      ? r.renderTemplatesSync(this.tpls, ctx)
-      : await r.renderTemplates(this.tpls, ctx)
+    const html = yield r.renderTemplates(this.tpls, ctx)
     if (blocks[''] === undefined) {
       blocks[''] = html
     }
-    const templates = ctx.sync
-      ? this.liquid.parseFileSync(layout, ctx.opts)
-      : await this.liquid.parseFile(layout, ctx.opts)
+    const templates = yield this.liquid._parseFile(layout, ctx.opts, ctx.sync)
     ctx.push(hash)
     ctx.setRegister('blockMode', BlockMode.OUTPUT)
-    const partial = ctx.sync
-      ? r.renderTemplatesSync(templates, ctx)
-      : await r.renderTemplates(templates, ctx)
+    const partial = yield r.renderTemplates(templates, ctx)
     ctx.pop()
     emitter.write(partial)
   }

--- a/src/builtin/tags/raw.ts
+++ b/src/builtin/tags/raw.ts
@@ -1,4 +1,4 @@
-import { TagToken, Token, ITagImplOptions, Context } from '../../types'
+import { Hash, Emitter, TagToken, Token, ITagImplOptions, Context } from '../../types'
 
 export default {
   parse: function (tagToken: TagToken, remainTokens: Token[]) {
@@ -15,7 +15,7 @@ export default {
       })
     stream.start()
   },
-  render: function (ctx: Context) {
-    return this.tokens.map((token: Token) => token.raw).join('')
+  render: function (ctx: Context, hash: Hash, emitter: Emitter) {
+    emitter.write(this.tokens.map((token: Token) => token.raw).join(''))
   }
 } as ITagImplOptions

--- a/src/builtin/tags/tablerow.ts
+++ b/src/builtin/tags/tablerow.ts
@@ -28,10 +28,8 @@ export default {
     stream.start()
   },
 
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
-    let collection = ctx.sync
-      ? new Expression(this.collection).valueSync(ctx) || []
-      : await new Expression(this.collection).value(ctx) || []
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
+    let collection = (yield new Expression(this.collection).value(ctx)) || []
     const offset = hash.offset || 0
     const limit = (hash.limit === undefined) ? collection.length : hash.limit
 
@@ -50,9 +48,7 @@ export default {
         emitter.write(`<tr class="row${tablerowloop.row()}">`)
       }
       emitter.write(`<td class="col${tablerowloop.col()}">`)
-      ctx.sync
-        ? r.renderTemplatesSync(this.templates, ctx, emitter)
-        : await r.renderTemplates(this.templates, ctx, emitter)
+      yield r.renderTemplates(this.templates, ctx, emitter)
       emitter.write('</td>')
     }
     if (collection.length) emitter.write('</tr>')

--- a/src/builtin/tags/unless.ts
+++ b/src/builtin/tags/unless.ts
@@ -20,18 +20,10 @@ export default {
     stream.start()
   },
 
-  renderSync: async function (ctx: Context, hash: Hash, emitter: Emitter) {
+  render: function * (ctx: Context, hash: Hash, emitter: Emitter) {
     const r = this.liquid.renderer
-    const cond = new Expression(this.cond).valueSync(ctx)
-    isFalsy(cond)
-      ? r.renderTemplatesSync(this.templates, ctx, emitter)
-      : r.renderTemplatesSync(this.elseTemplates, ctx, emitter)
-  },
-
-  render: async function (ctx: Context, hash: Hash, emitter: Emitter) {
-    const r = this.liquid.renderer
-    const cond = await new Expression(this.cond).value(ctx)
-    await (isFalsy(cond)
+    const cond = yield new Expression(this.cond).value(ctx)
+    yield (isFalsy(cond)
       ? r.renderTemplates(this.templates, ctx, emitter)
       : r.renderTemplates(this.elseTemplates, ctx, emitter))
   }

--- a/src/render/range.ts
+++ b/src/render/range.ts
@@ -7,20 +7,11 @@ export function isRange (token: string) {
   return token[0] === '(' && token[token.length - 1] === ')'
 }
 
-export async function rangeValue (token: string, ctx: Context) {
+export function * rangeValue (token: string, ctx: Context) {
   let match
   if ((match = token.match(rangeLine))) {
-    const low = await new Value(match[1]).value(ctx)
-    const high = await new Value(match[2]).value(ctx)
-    return range(+low, +high + 1)
-  }
-}
-
-export function rangeValueSync (token: string, ctx: Context) {
-  let match
-  if ((match = token.match(rangeLine))) {
-    const low = new Value(match[1]).valueSync(ctx)
-    const high = new Value(match[2]).valueSync(ctx)
+    const low = yield new Value(match[1]).value(ctx)
+    const high = yield new Value(match[2]).value(ctx)
     return range(+low, +high + 1)
   }
 }

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -4,26 +4,15 @@ import { ITemplate } from '../template/itemplate'
 import { Emitter } from './emitter'
 
 export class Render {
-  public async renderTemplates (templates: ITemplate[], ctx: Context, emitter = new Emitter()): Promise<string> {
+  public * renderTemplates (templates: ITemplate[], ctx: Context, emitter = new Emitter()): IterableIterator<string> {
     for (const tpl of templates) {
       try {
-        const html = await tpl.render(ctx, emitter)
+        const html = yield tpl.render(ctx, emitter)
         html && emitter.write(html)
         if (emitter.break || emitter.continue) break
       } catch (e) {
-        throw RenderError.is(e) ? e : new RenderError(e, tpl)
-      }
-    }
-    return emitter.html
-  }
-  public renderTemplatesSync (templates: ITemplate[], ctx: Context, emitter = new Emitter()): string {
-    for (const tpl of templates) {
-      try {
-        const html = tpl.renderSync(ctx, emitter)
-        html && !(html instanceof Promise) && emitter.write(html)
-        if (emitter.break || emitter.continue) break
-      } catch (e) {
-        throw RenderError.is(e) ? e : new RenderError(e, tpl)
+        const err = RenderError.is(e) ? e : new RenderError(e, tpl)
+        throw err
       }
     }
     return emitter.html

--- a/src/render/value.ts
+++ b/src/render/value.ts
@@ -9,11 +9,7 @@ export class Value {
     this.str = str
   }
 
-  public async evaluate (ctx: Context) {
-    return this.evaluateSync(ctx)
-  }
-
-  public evaluateSync (ctx: Context) {
+  public evaluate (ctx: Context) {
     const literalValue = parseLiteral(this.str)
     if (literalValue !== undefined) {
       return literalValue
@@ -21,11 +17,7 @@ export class Value {
     return ctx.get(this.str)
   }
 
-  public async value (ctx: Context) {
-    return toValue(await this.evaluate(ctx))
-  }
-
-  public valueSync (ctx: Context) {
-    return toValue(this.evaluateSync(ctx))
+  public value (ctx: Context) {
+    return toValue(this.evaluate(ctx))
   }
 }

--- a/src/template/filter/filter.ts
+++ b/src/template/filter/filter.ts
@@ -21,19 +21,11 @@ export class Filter {
     this.impl = impl || (x => x)
     this.args = args
   }
-  public async render (value: any, context: Context) {
+  public * render (value: any, context: Context) {
     const argv: any[] = []
     for (const arg of this.args) {
-      if (isKeyValuePair(arg)) argv.push([arg[0], await new Expression(arg[1]).evaluate(context)])
-      else argv.push(await new Expression(arg).evaluate(context))
-    }
-    return this.impl.apply({ context }, [value, ...argv])
-  }
-  public renderSync (value: any, context: Context) {
-    const argv: any[] = []
-    for (const arg of this.args) {
-      if (isKeyValuePair(arg)) argv.push([arg[0], new Expression(arg[1]).evaluateSync(context)])
-      else argv.push(new Expression(arg).evaluateSync(context))
+      if (isKeyValuePair(arg)) argv.push([arg[0], yield new Expression(arg[1]).evaluate(context)])
+      else argv.push(yield new Expression(arg).evaluate(context))
     }
     return this.impl.apply({ context }, [value, ...argv])
   }

--- a/src/template/html.ts
+++ b/src/template/html.ts
@@ -10,10 +10,7 @@ export class HTML extends Template<HTMLToken> implements ITemplate {
     super(token)
     this.str = token.value
   }
-  public renderSync (ctx: Context, emitter: Emitter) {
+  public * render (ctx: Context, emitter: Emitter): IterableIterator<void> {
     emitter.write(this.str)
-  }
-  public async render (ctx: Context, emitter: Emitter) {
-    this.renderSync(ctx, emitter)
   }
 }

--- a/src/template/itemplate.ts
+++ b/src/template/itemplate.ts
@@ -4,6 +4,5 @@ import { Emitter } from '../render/emitter'
 
 export interface ITemplate {
   token: Token;
-  render(ctx: Context, emitter: Emitter): Promise<any>;
-  renderSync(ctx: Context, emitter: Emitter): any;
+  render(ctx: Context, emitter: Emitter): any;
 }

--- a/src/template/output.ts
+++ b/src/template/output.ts
@@ -12,12 +12,8 @@ export class Output extends Template<OutputToken> implements ITemplate {
     super(token)
     this.value = new Value(token.value, strictFilters)
   }
-  public renderSync (ctx: Context, emitter: Emitter) {
-    const val = this.value.valueSync(ctx)
-    emitter.write(stringify(toValue(val)))
-  }
-  public async render (ctx: Context, emitter: Emitter) {
-    const val = await this.value.value(ctx)
+  public * render (ctx: Context, emitter: Emitter) {
+    const val = yield this.value.value(ctx)
     emitter.write(stringify(toValue(val)))
   }
 }

--- a/src/template/tag/hash.ts
+++ b/src/template/tag/hash.ts
@@ -21,17 +21,10 @@ export class Hash {
     }
     return instance
   }
-  public static createSync (markup: string, ctx: Context) {
+  public static * create (markup: string, ctx: Context) {
     const instance = Hash.parse(markup)
     for (const key of Object.keys(instance)) {
-      instance[key] = new Expression(instance[key]).evaluateSync(ctx)
-    }
-    return instance
-  }
-  public static async create (markup: string, ctx: Context) {
-    const instance = Hash.parse(markup)
-    for (const key of Object.keys(instance)) {
-      instance[key] = await new Expression(instance[key]).evaluate(ctx)
+      instance[key] = yield new Expression(instance[key]).evaluate(ctx)
     }
     return instance
   }

--- a/src/template/tag/itag-impl-options.ts
+++ b/src/template/tag/itag-impl-options.ts
@@ -7,6 +7,5 @@ import { Emitter } from '../../render/emitter'
 
 export interface ITagImplOptions {
   parse?: (this: ITagImpl, token: TagToken, remainingTokens: Token[]) => void;
-  render: (this: ITagImpl, ctx: Context, hash: Hash, emitter: Emitter) => void;
-  renderSync?: (this: ITagImpl, ctx: Context, hash: Hash, emitter: Emitter) => void;
+  render: (this: ITagImpl, ctx: Context, hash: Hash, emitter: Emitter) => any;
 }

--- a/src/template/tag/tag.ts
+++ b/src/template/tag/tag.ts
@@ -23,16 +23,10 @@ export class Tag extends Template<TagToken> implements ITemplate {
       this.impl.parse(token, tokens)
     }
   }
-  public renderSync (ctx: Context, emitter: Emitter) {
-    const hash = Hash.createSync(this.token.args, ctx)
+  public * render (ctx: Context, emitter: Emitter) {
+    const hash = yield Hash.create(this.token.args, ctx)
     const impl = this.impl
-    if (isFunction(impl.renderSync)) return impl.renderSync(ctx, hash, emitter)
-    if (isFunction(impl.render)) return impl.render(ctx, hash, emitter)
-  }
-  public async render (ctx: Context, emitter: Emitter) {
-    const hash = await Hash.create(this.token.args, ctx)
-    const impl = this.impl
-    if (isFunction(impl.render)) return impl.render(ctx, hash, emitter)
+    if (isFunction(impl.render)) return yield impl.render(ctx, hash, emitter)
   }
   public static register (name: string, tag: ITagImplOptions) {
     Tag.impls[name] = tag

--- a/src/template/value.ts
+++ b/src/template/value.ts
@@ -47,17 +47,10 @@ export class Value {
     }
     this.filters.push(new Filter(name, args, this.strictFilters))
   }
-  public async value (ctx: Context) {
-    let val = await new Expression(this.initial).evaluate(ctx)
+  public * value (ctx: Context) {
+    let val = yield new Expression(this.initial).evaluate(ctx)
     for (const filter of this.filters) {
-      val = await filter.render(val, ctx)
-    }
-    return val
-  }
-  public valueSync (ctx: Context) {
-    let val = new Expression(this.initial).evaluateSync(ctx)
-    for (const filter of this.filters) {
-      val = filter.renderSync(val, ctx)
+      val = yield filter.render(val, ctx)
     }
     return val
   }

--- a/src/util/async.ts
+++ b/src/util/async.ts
@@ -1,0 +1,75 @@
+import { isFunction } from './underscore'
+
+type resolver = (x?: any) => Thenable
+
+interface Thenable {
+  then (resolve: resolver, reject?: resolver): Thenable;
+  catch (reject: resolver): Thenable;
+}
+
+function mkResolve (value: any) {
+  const ret = {
+    then: (resolve: resolver) => resolve(value),
+    catch: () => ret
+  }
+  return ret
+}
+
+function mkReject (err: Error) {
+  const ret = {
+    then: (resolve: resolver, reject?: resolver) => {
+      if (reject) return reject(err)
+      return ret
+    },
+    catch: (reject: resolver) => reject(err)
+  }
+  return ret
+}
+
+function isThenable (val: any): val is Thenable {
+  return val && isFunction(val.then)
+}
+
+function isCustomIterable (val: any): val is IterableIterator<any> {
+  return val && isFunction(val.next) && isFunction(val.throw) && isFunction(val.return)
+}
+
+export function toThenable (val: IterableIterator<any> | Thenable): Thenable {
+  if (isThenable(val)) return val
+  if (isCustomIterable(val)) return reduce()
+  return mkResolve(val)
+
+  function reduce (prev?: any): Thenable {
+    let state
+    try {
+      state = (val as IterableIterator<any>).next(prev)
+    } catch (err) {
+      return mkReject(err)
+    }
+
+    if (state.done) return mkResolve(state.value)
+    return toThenable(state.value!).then(reduce, err => {
+      let state
+      try {
+        state = (val as IterableIterator<any>).throw!(err)
+      } catch (e) {
+        return mkReject(e)
+      }
+      if (state.done) return mkResolve(state.value)
+      return reduce(state.value)
+    })
+  }
+}
+
+export function toValue (val: IterableIterator<any> | Thenable) {
+  let ret: any
+  toThenable(val)
+    .then((x: any) => {
+      ret = x
+      return mkResolve(ret)
+    })
+    .catch((err: Error) => {
+      throw err
+    })
+  return ret
+}

--- a/test/integration/builtin/tags/include.ts
+++ b/test/integration/builtin/tags/include.ts
@@ -33,6 +33,7 @@ describe('tags/include', function () {
       '/parent.html': '{%include%}'
     })
     return liquid.renderFile('/parent.html').catch(function (e) {
+      console.log(e)
       expect(e.name).to.equal('RenderError')
       expect(e.message).to.match(/cannot include with empty filename/)
     })

--- a/test/integration/liquid/liquid.ts
+++ b/test/integration/liquid/liquid.ts
@@ -77,4 +77,54 @@ describe('Liquid', function () {
         .be.rejectedWith(/Failed to lookup "\/not\/exist.html" in "\/boo,\/root\/"/)
     })
   })
+  describe('#parseFile', function () {
+    it('should throw with lookup list when file not exist', function () {
+      const engine = new Liquid({
+        root: ['/boo', '/root/'],
+        extname: '.html'
+      })
+      return expect(engine.parseFile('/not/exist.html')).to
+        .be.rejectedWith(/Failed to lookup "\/not\/exist.html" in "\/boo,\/root\/"/)
+    })
+    it('should throw with lookup list when file not exist', function () {
+      const engine = new Liquid({
+        root: ['/boo', '/root/'],
+        extname: '.html'
+      })
+      return expect(engine.getTemplate('/not/exist.html')).to
+        .be.rejectedWith(/Failed to lookup "\/not\/exist.html" in "\/boo,\/root\/"/)
+    })
+  })
+  describe('#evalValue', function () {
+    it('should eval string literal', async function () {
+      const engine = new Liquid()
+      const str = await engine.evalValue('"foo"', {} as any)
+      expect(str).to.equal('foo')
+    })
+  })
+  describe('#evalValueSync', function () {
+    it('should eval string literal', function () {
+      const engine = new Liquid()
+      const str = engine.evalValueSync('"foo"', {} as any)
+      expect(str).to.equal('foo')
+    })
+  })
+  describe('#parseFileSync', function () {
+    it('should throw with lookup list when file not exist', function () {
+      const engine = new Liquid({
+        root: ['/boo', '/root/'],
+        extname: '.html'
+      })
+      return expect(() => engine.parseFileSync('/not/exist.html'))
+        .to.throw(/Failed to lookup "\/not\/exist.html" in "\/boo,\/root\/"/)
+    })
+    it('should throw with lookup list when file not exist', function () {
+      const engine = new Liquid({
+        root: ['/boo', '/root/'],
+        extname: '.html'
+      })
+      return expect(() => engine.getTemplateSync('/not/exist.html'))
+        .to.throw(/Failed to lookup "\/not\/exist.html" in "\/boo,\/root\/"/)
+    })
+  })
 })

--- a/test/unit/render/expression.ts
+++ b/test/unit/render/expression.ts
@@ -1,6 +1,7 @@
 import { Expression } from '../../../src/render/expression'
 import { expect } from 'chai'
 import { Context } from '../../../src/context/context'
+import { toThenable } from '../../../src/util/async'
 
 describe('Expression', function () {
   let ctx: Context
@@ -16,57 +17,57 @@ describe('Expression', function () {
     })
   })
 
-  it('should throw when context not defined', async function () {
-    return expect(new Expression().value()).to.be.rejectedWith(/context not defined/)
+  it('should throw when context not defined', done => {
+    toThenable(new Expression().value(undefined!)).catch(err => {
+      expect(err.message).to.match(/context not defined/)
+      done()
+      return 0 as any
+    })
   })
 
   it('should eval simple expression', async function () {
-    expect(await new Expression('1 < 2').value(ctx)).to.equal(true)
-    expect(await new Expression('1   <   2').value(ctx)).to.equal(true)
-    expect(await new Expression('2 <= 2').value(ctx)).to.equal(true)
-    expect(await new Expression('one <= two').value(ctx)).to.equal(true)
-    expect(await new Expression('x contains "x"').value(ctx)).to.equal(false)
-    expect(await new Expression('x contains "X"').value(ctx)).to.equal(true)
-    expect(await new Expression('1 contains "x"').value(ctx)).to.equal(false)
-    expect(await new Expression('y contains "x"').value(ctx)).to.equal(false)
-    expect(await new Expression('z contains "x"').value(ctx)).to.equal(false)
-    expect(await new Expression('(1..5) contains 3').value(ctx)).to.equal(true)
-    expect(await new Expression('(1..5) contains 6').value(ctx)).to.equal(false)
-    expect(await new Expression('"<=" == "<="').value(ctx)).to.equal(true)
+    expect(await toThenable(new Expression('1 < 2').value(ctx))).to.equal(true)
+    expect(await toThenable(new Expression('1   <   2').value(ctx))).to.equal(true)
+    expect(await toThenable(new Expression('2 <= 2').value(ctx))).to.equal(true)
+    expect(await toThenable(new Expression('one <= two').value(ctx))).to.equal(true)
+    expect(await toThenable(new Expression('x contains "x"').value(ctx))).to.equal(false)
+    expect(await toThenable(new Expression('x contains "X"').value(ctx))).to.equal(true)
+    expect(await toThenable(new Expression('1 contains "x"').value(ctx))).to.equal(false)
+    expect(await toThenable(new Expression('y contains "x"').value(ctx))).to.equal(false)
+    expect(await toThenable(new Expression('z contains "x"').value(ctx))).to.equal(false)
+    expect(await toThenable(new Expression('(1..5) contains 3').value(ctx))).to.equal(true)
+    expect(await toThenable(new Expression('(1..5) contains 6').value(ctx))).to.equal(false)
+    expect(await toThenable(new Expression('"<=" == "<="').value(ctx))).to.equal(true)
   })
 
   describe('complex expression', function () {
     it('should support value or value', async function () {
-      expect(await new Expression('false or true').value(ctx)).to.equal(true)
+      expect(await toThenable(new Expression('false or true').value(ctx))).to.equal(true)
     })
     it('should support < and contains', async function () {
-      expect(await new Expression('1 < 2 and x contains "x"').value(ctx)).to.equal(false)
+      expect(await toThenable(new Expression('1 < 2 and x contains "x"').value(ctx))).to.equal(false)
     })
     it('should support < or contains', async function () {
-      expect(await new Expression('1 < 2 or x contains "x"').value(ctx)).to.equal(true)
+      expect(await toThenable(new Expression('1 < 2 or x contains "x"').value(ctx))).to.equal(true)
     })
     it('should support value and !=', async function () {
-      expect(await new Expression('empty and empty != ""').value(ctx)).to.equal(false)
+      expect(await toThenable(new Expression('empty and empty != ""').value(ctx))).to.equal(false)
     })
     it('should recognize quoted value', async function () {
-      expect(await new Expression('">"').value(ctx)).to.equal('>')
+      expect(await toThenable(new Expression('">"').value(ctx))).to.equal('>')
     })
     it('should evaluate from right to left', async function () {
-      expect(await new Expression('true or false and false').value(ctx)).to.equal(true)
-      expect(await new Expression('true and false and false or true').value(ctx)).to.equal(false)
+      expect(await toThenable(new Expression('true or false and false').value(ctx))).to.equal(true)
+      expect(await toThenable(new Expression('true and false and false or true').value(ctx))).to.equal(false)
     })
     it('should recognize property access', async function () {
       const ctx = new Context({ obj: { foo: true } })
-      expect(await new Expression('obj["foo"] and true').value(ctx)).to.equal(true)
+      expect(await toThenable(new Expression('obj["foo"] and true').value(ctx))).to.equal(true)
     })
   })
 
   it('should eval range expression', async function () {
-    expect(await new Expression('(2..4)').value(ctx)).to.deep.equal([2, 3, 4])
-    expect(await new Expression('(two..4)').value(ctx)).to.deep.equal([2, 3, 4])
-  })
-
-  it('should support sync', function () {
-    expect(new Expression('empty and empty != ""').valueSync(ctx)).to.equal(false)
+    expect(await toThenable(new Expression('(2..4)').value(ctx))).to.deep.equal([2, 3, 4])
+    expect(await toThenable(new Expression('(two..4)').value(ctx))).to.deep.equal([2, 3, 4])
   })
 })

--- a/test/unit/render/render.ts
+++ b/test/unit/render/render.ts
@@ -5,6 +5,7 @@ import { Tag } from '../../../src/template/tag/tag'
 import { Filter } from '../../../src/template/filter/filter'
 import { Render } from '../../../src/render/render'
 import { HTML } from '../../../src/template/html'
+import { toThenable } from '../../../src/util/async'
 
 describe('render', function () {
   let render: Render
@@ -15,14 +16,10 @@ describe('render', function () {
   })
 
   describe('.renderTemplates()', function () {
-    it('should throw when scope undefined', function () {
-      expect(render.renderTemplates([], null as any)).to.be.rejectedWith(/scope undefined/)
-    })
-
     it('should render html', async function () {
       const scope = new Context()
       const token = { type: 'html', value: '<p>' } as Token
-      const html = await render.renderTemplates([new HTML(token)], scope)
+      const html = await toThenable(render.renderTemplates([new HTML(token)], scope))
       return expect(html).to.equal('<p>')
     })
   })

--- a/test/unit/render/value.ts
+++ b/test/unit/render/value.ts
@@ -5,20 +5,20 @@ import { expect } from 'chai'
 describe('Value', function () {
   it('should eval number variable', async function () {
     const ctx = new Context({ one: 1 })
-    expect(new Value('one').valueSync(ctx)).to.equal(1)
+    expect(new Value('one').value(ctx)).to.equal(1)
   })
   it('question mark should be valid variable name', async function () {
     const ctx = new Context({ 'has_value?': true })
-    expect(new Value('has_value?').valueSync(ctx)).to.equal(true)
+    expect(new Value('has_value?').value(ctx)).to.equal(true)
   })
   it('should eval string variable', async function () {
     const ctx = new Context({ x: 'XXX' })
-    expect(new Value('x').valueSync(ctx)).to.equal('XXX')
+    expect(new Value('x').value(ctx)).to.equal('XXX')
   })
   it('should eval null literal', async function () {
-    expect(new Value('null').valueSync({})).to.be.null
+    expect(new Value('null').value({} as any)).to.be.null
   })
   it('should eval nil literal', async function () {
-    expect(new Value('nil').valueSync({})).to.be.null
+    expect(new Value('nil').value({} as any)).to.be.null
   })
 })

--- a/test/unit/template/hash.ts
+++ b/test/unit/template/hash.ts
@@ -1,4 +1,5 @@
 import * as chai from 'chai'
+import { toThenable } from '../../../src/util/async'
 import { Hash } from '../../../src/template/tag/hash'
 import { Context } from '../../../src/context/context'
 
@@ -6,15 +7,11 @@ const expect = chai.expect
 
 describe('Hash', function () {
   it('should parse variable', async function () {
-    const hash = await Hash.create('num:foo', new Context({ foo: 3 }))
+    const hash = await toThenable(Hash.create('num:foo', new Context({ foo: 3 })))
     expect(hash.num).to.equal(3)
   })
   it('should parse literals', async function () {
-    const hash = await Hash.create('num:3', new Context())
-    expect(hash.num).to.equal(3)
-  })
-  it('should support sync', function () {
-    const hash = Hash.createSync('num:3', new Context())
+    const hash = await toThenable(Hash.create('num:3', new Context()))
     expect(hash.num).to.equal(3)
   })
 })

--- a/test/unit/template/output.ts
+++ b/test/unit/template/output.ts
@@ -1,4 +1,5 @@
 import * as chai from 'chai'
+import { toThenable } from '../../../src/util/async'
 import { Context } from '../../../src/context/context'
 import { Output } from '../../../src/template/output'
 import { OutputToken } from '../../../src/parser/output-token'
@@ -7,7 +8,7 @@ import { Filter } from '../../../src/template/filter/filter'
 const expect = chai.expect
 
 describe('Output', function () {
-  const emitter = { write: (html: string) => (emitter.html += html), html: '' }
+  const emitter: any = { write: (html: string) => (emitter.html += html), html: '' }
   beforeEach(function () {
     Filter.clear()
     emitter.html = ''
@@ -18,25 +19,25 @@ describe('Output', function () {
       foo: { obj: { arr: ['a', 2] } }
     })
     const output = new Output({ value: 'foo' } as OutputToken, false)
-    await output.render(scope, emitter)
+    await toThenable(output.render(scope, emitter))
     return expect(emitter.html).to.equal('[object Object]')
   })
   it('should skip function property', async function () {
     const scope = new Context({ obj: { foo: 'foo', bar: (x: any) => x } })
     const output = new Output({ value: 'obj' } as OutputToken, false)
-    await output.render(scope, emitter)
+    await toThenable(output.render(scope, emitter))
     return expect(emitter.html).to.equal('[object Object]')
   })
   it('should respect to .toString()', async () => {
     const scope = new Context({ obj: { toString: () => 'FOO' } })
     const output = new Output({ value: 'obj' } as OutputToken, false)
-    await output.render(scope, emitter)
+    await toThenable(output.render(scope, emitter))
     return expect(emitter.html).to.equal('FOO')
   })
   it('should respect to .toString()', async () => {
     const scope = new Context({ obj: { toString: () => 'FOO' } })
     const output = new Output({ value: 'obj' } as OutputToken, false)
-    await output.render(scope, emitter)
+    await toThenable(output.render(scope, emitter))
     return expect(emitter.html).to.equal('FOO')
   })
 })

--- a/test/unit/template/tag.ts
+++ b/test/unit/template/tag.ts
@@ -5,6 +5,7 @@ import * as sinon from 'sinon'
 import * as sinonChai from 'sinon-chai'
 import { Liquid } from '../../../src/liquid'
 import { TagToken } from '../../../src/parser/tag-token'
+import { toThenable } from '../../../src/util/async'
 
 chai.use(sinonChai)
 const expect = chai.expect
@@ -12,7 +13,7 @@ const liquid = new Liquid()
 
 describe('Tag', function () {
   let ctx: Context
-  const emitter = { write: (html: string) => (emitter.html += html), html: '' }
+  const emitter: any = { write: (html: string) => (emitter.html += html), html: '' }
   before(function () {
     ctx = new Context({
       foo: 'bar',
@@ -55,7 +56,7 @@ describe('Tag', function () {
       value: 'foo',
       name: 'foo'
     } as TagToken
-    await new Tag(token, [], liquid).render(ctx, emitter)
+    await toThenable(new Tag(token, [], liquid).render(ctx, emitter))
     expect(spy).to.have.been.called
   })
 
@@ -74,29 +75,29 @@ describe('Tag', function () {
       } as TagToken
     })
     it('should call tag.render with scope', async function () {
-      await new Tag(token, [], liquid).render(ctx, emitter)
+      await toThenable(new Tag(token, [], liquid).render(ctx, emitter))
       expect(spy).to.have.been.calledWithMatch(ctx)
     })
     it('should resolve identifier hash', async function () {
-      await new Tag(token, [], liquid).render(ctx, emitter)
+      await toThenable(new Tag(token, [], liquid).render(ctx, emitter))
       expect(spy).to.have.been.calledWithMatch({}, {
         aa: 'bar'
       })
     })
     it('should accept space between key/value', async function () {
-      await new Tag(token, [], liquid).render(ctx, emitter)
+      await toThenable(new Tag(token, [], liquid).render(ctx, emitter))
       expect(spy).to.have.been.calledWithMatch({}, {
         bb: 2
       })
     })
     it('should resolve number value hash', async function () {
-      await new Tag(token, [], liquid).render(ctx, emitter)
+      await toThenable(new Tag(token, [], liquid).render(ctx, emitter))
       expect(spy).to.have.been.calledWithMatch(ctx, {
         cc: 2.3
       })
     })
     it('should resolve property access hash', async function () {
-      await new Tag(token, [], liquid).render(ctx, emitter)
+      await toThenable(new Tag(token, [], liquid).render(ctx, emitter))
       expect(spy).to.have.been.calledWithMatch(ctx, {
         dd: 'uoo'
       })

--- a/test/unit/template/value.ts
+++ b/test/unit/template/value.ts
@@ -1,4 +1,5 @@
 import * as chai from 'chai'
+import { toThenable } from '../../../src/util/async'
 import * as sinonChai from 'sinon-chai'
 import * as sinon from 'sinon'
 import { Context } from '../../../src/context/context'
@@ -120,7 +121,7 @@ describe('Value', function () {
       const scope = new Context({
         foo: { bar: 'bar' }
       })
-      await tpl.value(scope)
+      await toThenable(tpl.value(scope))
       expect(date).to.have.been.calledWith('bar', 'b')
       expect(time).to.have.been.calledWith('y', 2)
     })

--- a/test/unit/util/async.ts
+++ b/test/unit/util/async.ts
@@ -1,0 +1,106 @@
+import { toThenable, toValue } from '../../../src/util/async'
+import { expect, use } from 'chai'
+import * as chaiAsPromised from 'chai-as-promised'
+
+use(chaiAsPromised)
+
+describe('utils/async', () => {
+  describe('#toThenable()', function () {
+    it('should support iterable with single return statement', async () => {
+      function * foo () {
+        return 'foo'
+      }
+      const result = await toThenable(foo())
+      expect(result).to.equal('foo')
+    })
+    it('should support promise', async () => {
+      function foo () {
+        return Promise.resolve('foo')
+      }
+      const result = await toThenable(foo())
+      expect(result).to.equal('foo')
+    })
+    it('should resolve dependency', async () => {
+      function * foo () {
+        return yield bar()
+      }
+      function * bar () {
+        return 'bar'
+      }
+      const result = await toThenable(foo())
+      expect(result).to.equal('bar')
+    })
+    it('should support promise dependency', async () => {
+      function * foo () {
+        return yield Promise.resolve('foo')
+      }
+      const result = await toThenable(foo())
+      expect(result).to.equal('foo')
+    })
+    it('should reject Promise if dependency throws syncly', done => {
+      function * foo () {
+        return yield bar()
+      }
+      function * bar (): IterableIterator<any> {
+        throw new Error('bar')
+      }
+      toThenable(foo()).catch(err => {
+        expect(err.message).to.equal('bar')
+        done()
+        return 0 as any
+      })
+    })
+    it('should resume promise after catch', async () => {
+      function * foo () {
+        let ret = ''
+        try {
+          yield bar()
+        } catch (e) {
+          ret += 'bar'
+        }
+        ret += 'foo'
+        return ret
+      }
+      function * bar (): IterableIterator<any> {
+        throw new Error('bar')
+      }
+      const ret = await toThenable(foo())
+      expect(ret).to.equal('barfoo')
+    })
+  })
+  describe('#toValue()', function () {
+    it('should throw Error if dependency throws syncly', () => {
+      function * foo () {
+        return yield bar()
+      }
+      function * bar (): IterableIterator<any> {
+        throw new Error('bar')
+      }
+      expect(() => toValue(foo())).to.throw('bar')
+    })
+    it('should resume yield after catch', () => {
+      function * foo () {
+        try {
+          yield bar()
+        } catch (e) {}
+        return yield 'foo'
+      }
+      function * bar (): IterableIterator<any> {
+        throw new Error('bar')
+      }
+      expect(toValue(foo())).to.equal('foo')
+    })
+    it('should resume return after catch', () => {
+      function * foo () {
+        try {
+          yield bar()
+        } catch (e) {}
+        return 'foo'
+      }
+      function * bar (): IterableIterator<any> {
+        throw new Error('bar')
+      }
+      expect(toValue(foo())).to.equal('foo')
+    })
+  })
+})


### PR DESCRIPTION
Remove await/async keywords for internal function calls, so we can remove redundent async/sync implementations (see: https://github.com/harttle/liquidjs/issues/164) and reduce bundle size. This refactor improves performance (both ops/sec and mem used) considerably:

```
Before refactor:
--- output ---
literal x 16,091 ops/sec ±6.03% (76 runs sampled)
truncate x 21,693 ops/sec ±4.97% (72 runs sampled)
date x 20,426 ops/sec ±4.66% (77 runs sampled)
escape x 25,261 ops/sec ±5.09% (76 runs sampled)
default x 22,055 ops/sec ±4.74% (76 runs sampled)
--- tag ---
if x 20,408 ops/sec ±4.98% (74 runs sampled)
unless x 19,867 ops/sec ±4.87% (77 runs sampled)
for x 8,185 ops/sec ±5.21% (73 runs sampled)
switch x 9,488 ops/sec ±6.23% (73 runs sampled)
assign x 25,552 ops/sec ±5.10% (79 runs sampled)
capture x 27,401 ops/sec ±6.08% (75 runs sampled)
increment x 50,359 ops/sec ±4.99% (78 runs sampled)
decrement x 50,226 ops/sec ±5.80% (74 runs sampled)
tablerow x 9,732 ops/sec ±5.75% (74 runs sampled)
--- demo ---
demo x 3,892 ops/sec ±5.62% (77 runs sampled)
--- layout ---
cache=false x 3,658 ops/sec ±5.70% (69 runs sampled)
cache=true x 8,815 ops/sec ±4.77% (77 runs sampled)
--- memory ---
retained memory for a 3KB template: 16.781KB (250 samples)

After refactor:
--- output ---
literal x 55,118 ops/sec ±2.82% (79 runs sampled)
truncate x 54,365 ops/sec ±2.79% (79 runs sampled)
date x 51,431 ops/sec ±2.59% (80 runs sampled)
escape x 61,429 ops/sec ±3.00% (81 runs sampled)
default x 57,999 ops/sec ±2.77% (76 runs sampled)
--- tag ---
if x 55,281 ops/sec ±2.59% (82 runs sampled)
unless x 47,726 ops/sec ±3.64% (78 runs sampled)
for x 27,228 ops/sec ±2.29% (83 runs sampled)
switch x 28,609 ops/sec ±3.63% (81 runs sampled)
assign x 67,104 ops/sec ±3.71% (78 runs sampled)
capture x 64,171 ops/sec ±2.98% (79 runs sampled)
increment x 95,346 ops/sec ±3.68% (79 runs sampled)
decrement x 92,262 ops/sec ±3.93% (74 runs sampled)
tablerow x 33,876 ops/sec ±3.14% (79 runs sampled)
--- demo ---
demo x 11,217 ops/sec ±2.28% (80 runs sampled)
--- layout ---
cache=false x 6,194 ops/sec ±2.64% (73 runs sampled)
cache=true x 25,483 ops/sec ±2.53% (82 runs sampled)
--- memory ---
retained memory for a 3KB template: 5.30240625KB (250 samples)
```

In summary, on MacBook 11,1 (2.4 GHz Core i5, 8G RAM) improves include:

* ops/sec for typical use cases improved by x2.5 (see above)
* memory usage reduced by 2/2 (see above)
* size of liquidjs.min.js reduced by 14% (50k -> 43k)