### PR TITLE
Add ability to pass JSON context to CLI

### DIFF
--- a/bin/liquid.js
+++ b/bin/liquid.js
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
 
 const Liquid = require('..').Liquid
+var contextArg = process.argv.slice(2)[0]
+var context = {}
+
+if (contextArg) {
+  if (contextArg.endsWith('.json')) {
+    const fs = require('fs')
+    context = JSON.parse(fs.readFileSync(contextArg, 'utf8'))
+  } else {
+    context = JSON.parse(contextArg)
+  }
+}
 
 let tpl = ''
 process.stdin.on('data', chunk => (tpl += chunk))
@@ -8,6 +19,6 @@ process.stdin.on('end', () => render(tpl))
 
 async function render (tpl) {
   const liquid = new Liquid()
-  const html = await liquid.parseAndRender(tpl)
+  const html = await liquid.parseAndRender(tpl, context)
   console.log(html)
 }


### PR DESCRIPTION
If you pass a JSON file or JSON string as the first argument to the CLI, you can use variables in your templates that get parsed by the CLI.