### PR TITLE
Add `funding` entry to show up in `npm fund`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "type": "git",
     "url": "git+https://github.com/harttle/liquidjs.git"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/liquidjs"
+  },
   "files": [
     "bin",
     "dist",


### PR DESCRIPTION
For example liquidjs is missing when I run:
![image](https://user-images.githubusercontent.com/39355/74533778-fdca3e80-4ef7-11ea-976c-221bb78e15cb.png)
