### PR TITLE
fix: add funding entry to show up in npm fund command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "type": "git",
     "url": "git+https://github.com/harttle/liquidjs.git"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/liquidjs"
+  },
   "files": [
     "bin",
     "dist",


### PR DESCRIPTION
Fixed PR via https://github.com/harttle/liquidjs/pull/189#issuecomment-586281885