### PR TITLE
fix: keep orignal order if inputs are nil for `caseInsensitiveCmp`

### DIFF
--- a/src/builtin/filters/math.ts
+++ b/src/builtin/filters/math.ts
@@ -19,8 +19,8 @@ export default {
 }
 
 function caseInsensitiveCmp (a: any, b: any) {
-  if (!b) return -1
   if (!a) return 1
+  if (!b) return -1
   a = toLowerCase.call(a)
   b = toLowerCase.call(b)
   if (a < b) return -1

--- a/test/integration/builtin/filters/math.ts
+++ b/test/integration/builtin/filters/math.ts
@@ -99,6 +99,16 @@ describe('filters/math', function () {
       const html = await l.parseAndRender(src, { students })
       expect(html).to.equal('alice bob carol')
     })
+    it('keep orignal order based on specified property', async () => {
+      const src = '{{ students | sort_natural: "age" | map: "name" | join }}'
+      const students = [
+        { name: 'bob' },
+        { name: 'alice', age: 2 },
+        { name: 'amber' }
+      ]
+      const html = await l.parseAndRender(src, { students })
+      expect(html).to.equal('alice bob amber')
+    })
     it('should tolerate non array', async () => {
       const src = '{{ students | sort_natural: "age" | map: "name" | join }}'
       const html = await l.parseAndRender(src, { students: {} })


### PR DESCRIPTION
in function `caseInsensitiveCmp`, to keep original order when other items with specified property `undefined`, we should use logic like below:

```typescript
function caseInsensitiveCmp (a: any, b: any) {
    if (!a && !b) return 1
    else if (!a) return 1
    else if (!b) return -1
    ...
}
```

simplify it, we got
```typescript
function caseInsensitiveCmp (a: any, b: any) {
    if (!a) return 1
    if (!b) return -1
    ...
}
```