### PR TITLE
fix: return variable name in include error

### DIFF
--- a/src/builtin/tags/include.ts
+++ b/src/builtin/tags/include.ts
@@ -29,7 +29,7 @@ export default {
         ? yield renderer.renderTemplates(liquid.parse(evalQuotedToken(file)), ctx)
         : yield evalToken(file, ctx))
       : file.getText()
-    assert(filepath, () => `illegal filename "${file}":"${filepath}"`)
+    assert(filepath, () => `illegal filename "${file.getText()}":"${filepath}"`)
 
     const saved = ctx.saveRegister('blocks', 'blockMode')
     ctx.setRegister('blocks', {})

--- a/test/integration/builtin/tags/include.ts
+++ b/test/integration/builtin/tags/include.ts
@@ -44,7 +44,7 @@ describe('tags/include', function () {
     })
     return liquid.renderFile('/parent.html').catch(function (e) {
       expect(e.name).to.equal('RenderError')
-      expect(e.message).to.match(/illegal filename/)
+      expect(e.message).to.match(/illegal filename "not-exist"/)
     })
   })
 


### PR DESCRIPTION
Adds a `getText()` missing in #205. Without it the error message started always with `illegal filename "[object Object]"`