### PR TITLE
fix: respect cache render options

### DIFF
--- a/src/liquid-options.ts
+++ b/src/liquid-options.ts
@@ -89,11 +89,13 @@ export function normalize (options?: LiquidOptions): NormalizedOptions {
   if (options.hasOwnProperty('root')) {
     options.root = normalizeStringArray(options.root)
   }
-  let cache: Cache<Template[]> | undefined
-  if (typeof options.cache === 'number') cache = options.cache > 0 ? new LRU(options.cache) : undefined
-  else if (typeof options.cache === 'object') cache = options.cache
-  else cache = options.cache ? new LRU<Template[]>(1024) : undefined
-  options.cache = cache
+  if (options.hasOwnProperty('cache')) {
+    let cache: Cache<Template[]> | undefined
+    if (typeof options.cache === 'number') cache = options.cache > 0 ? new LRU(options.cache) : undefined
+    else if (typeof options.cache === 'object') cache = options.cache
+    else cache = options.cache ? new LRU<Template[]>(1024) : undefined
+    options.cache = cache
+  }
   return options as NormalizedOptions
 }
 

--- a/src/liquid.ts
+++ b/src/liquid.ts
@@ -75,7 +75,7 @@ export class Liquid {
     }
 
     for (const filepath of paths) {
-      const { cache } = this.options
+      const { cache } = options
       if (cache) {
         const tpls = yield cache.read(filepath)
         if (tpls) return tpls

--- a/test/integration/liquid/cache.ts
+++ b/test/integration/liquid/cache.ts
@@ -132,6 +132,34 @@ describe('LiquidOptions#cache', function () {
       const y = await engine.renderFile('foo')
       expect(y).to.equal('foo')
     })
+    it('should respect passed in cache=false option', async function () {
+      const engine = new Liquid({
+        root: '/root/',
+        extname: '.html',
+        cache: true
+      })
+      mock({ '/root/files/foo.html': 'foo' })
+      const x = await engine.renderFile('files/foo')
+      expect(x).to.equal('foo')
+      mock({ '/root/files/foo.html': 'bar' })
+      const y = await engine.renderFile('files/foo')
+      expect(y).to.equal('foo')
+      const z = await engine.renderFile('files/foo', undefined, { cache: false })
+      expect(z).to.equal('bar')
+    })
+    it('should use cache when passing in other options', async function () {
+      const engine = new Liquid({
+        root: '/root/',
+        extname: '.html',
+        cache: true
+      })
+      mock({ '/root/files/foo.html': 'foo' })
+      const x = await engine.renderFile('files/foo')
+      expect(x).to.equal('foo')
+      mock({ '/root/files/foo.html': 'bar' })
+      const y = await engine.renderFile('files/foo', undefined, { greedy: true })
+      expect(y).to.equal('foo')
+    })
   })
 
   describe('#renderFileSync', function () {
@@ -172,6 +200,34 @@ describe('LiquidOptions#cache', function () {
 
       mock({ '/root/foo.html': 'foo' })
       const y = await engine.renderFile('foo')
+      expect(y).to.equal('foo')
+    })
+    it('should respect passed in cache=false option', async function () {
+      const engine = new Liquid({
+        root: '/root/',
+        extname: '.html',
+        cache: true
+      })
+      mock({ '/root/files/foo.html': 'foo' })
+      const x = engine.renderFileSync('files/foo')
+      expect(x).to.equal('foo')
+      mock({ '/root/files/foo.html': 'bar' })
+      const y = engine.renderFileSync('files/foo')
+      expect(y).to.equal('foo')
+      const z = engine.renderFileSync('files/foo', undefined, { cache: false })
+      expect(z).to.equal('bar')
+    })
+    it('should use cache when passing in other options', async function () {
+      const engine = new Liquid({
+        root: '/root/',
+        extname: '.html',
+        cache: true
+      })
+      mock({ '/root/files/foo.html': 'foo' })
+      const x = engine.renderFileSync('files/foo')
+      expect(x).to.equal('foo')
+      mock({ '/root/files/foo.html': 'bar' })
+      const y = engine.renderFileSync('files/foo', undefined, { greedy: true })
       expect(y).to.equal('foo')
     })
   })


### PR DESCRIPTION
I tried to disable the cache for a single renderFile call and discovered this bug. 
The passed in cache option would always be ignored. 