### PR TITLE
lenientIf option: Make 'if' and 'default' more useful with undefined variables

### DIFF
--- a/docs/source/tutorials/options.md
+++ b/docs/source/tutorials/options.md
@@ -89,7 +89,7 @@ it defaults to false.  For example, when set to true, a blank string would evalu
 
 **strictVariables** is used to assert variable existence.  If set to `false`, undefined variables will be rendered as empty string.  Otherwise, undefined variables will cause a render exception. Defaults to `false`.
 
-**lenientIf** modifies the behavior of `strictVariables` to allow handling optional variables. If set to `true`, an undefined variable will *not* cause an exception in the following two situations: a) it is the condition to an `if` or `elsif` tag; b) it occurs right before a `default` filter. Irrelevant if `strictVariables` is not set. Defaults to `false`.
+**lenientIf** modifies the behavior of `strictVariables` to allow handling optional variables. If set to `true`, an undefined variable will *not* cause an exception in the following two situations: a) it is the condition to an `if`, `elsif`, or `unless` tag; b) it occurs right before a `default` filter. Irrelevant if `strictVariables` is not set. Defaults to `false`.
 
 {% note info Non-existent Tags %}
 Non-existent tags always throw errors during pasrsing and this behaviour can not be customized.

--- a/docs/source/tutorials/options.md
+++ b/docs/source/tutorials/options.md
@@ -67,7 +67,7 @@ Before 2.0.1, <code>extname</code> is set to `.liquid` by default. To change tha
 
 ## jsTruthy
 
-**jsTruthy** is used to use standard Javascript truthiness rather than the Shopify. 
+**jsTruthy** is used to use standard Javascript truthiness rather than the Shopify.
 
 it defaults to false.  For example, when set to true, a blank string would evaluate to false with jsTruthy. With Shopify's truthiness, a blank string is true.
 
@@ -88,6 +88,8 @@ it defaults to false.  For example, when set to true, a blank string would evalu
 **strictFilters** is used to assert filter existence. If set to `false`, undefined filters will be skipped. Otherwise, undefined filters will cause a parse exception. Defaults to `false`.
 
 **strictVariables** is used to assert variable existence.  If set to `false`, undefined variables will be rendered as empty string.  Otherwise, undefined variables will cause a render exception. Defaults to `false`.
+
+**lenientIf** modifies the behavior of `strictVariables` to allow handling optional variables. If set to `true`, an undefined variable will *not* cause an exception in the following two situations: a) it is the condition to an `if` or `elsif` tag; b) it occurs right before a `default` filter. Irrelevant if `strictVariables` is not set. Defaults to `false`.
 
 {% note info Non-existent Tags %}
 Non-existent tags always throw errors during pasrsing and this behaviour can not be customized.

--- a/src/builtin/tags/if.ts
+++ b/src/builtin/tags/if.ts
@@ -31,7 +31,7 @@ export default {
     const r = this.liquid.renderer
 
     for (const branch of this.branches) {
-      const cond = yield new Expression(branch.cond).value(ctx)
+      const cond = yield new Expression(branch.cond, ctx.opts.lenientIf).value(ctx)
       if (isTruthy(cond, ctx)) {
         yield r.renderTemplates(branch.templates, ctx, emitter)
         return

--- a/src/builtin/tags/unless.ts
+++ b/src/builtin/tags/unless.ts
@@ -22,7 +22,7 @@ export default {
 
   render: function * (ctx: Context, emitter: Emitter) {
     const r = this.liquid.renderer
-    const cond = yield new Expression(this.cond).value(ctx)
+    const cond = yield new Expression(this.cond, ctx.opts.lenientIf).value(ctx)
     yield (isFalsy(cond, ctx)
       ? r.renderTemplates(this.templates, ctx, emitter)
       : r.renderTemplates(this.elseTemplates, ctx, emitter))

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -3,6 +3,7 @@ import { __assign } from 'tslib'
 import { NormalizedFullOptions, defaultOptions } from '../liquid-options'
 import { Scope } from './scope'
 import { isArray, isNil, isString, isFunction, toLiquid } from '../util/underscore'
+import { InternalUndefinedVariableError } from '../util/error'
 
 export class Context {
   private scopes: Scope[] = [{}]
@@ -42,7 +43,7 @@ export class Context {
     return paths.reduce((scope, path) => {
       scope = readProperty(scope, path)
       if (isNil(scope) && this.opts.strictVariables) {
-        throw new TypeError(`undefined variable: ${path}`)
+        throw new InternalUndefinedVariableError(path)
       }
       return scope
     }, scope)

--- a/src/liquid-options.ts
+++ b/src/liquid-options.ts
@@ -19,7 +19,7 @@ export interface LiquidOptions {
   strictFilters?: boolean;
   /** Whether or not to assert variable existence.  If set to `false`, undefined variables will be rendered as empty string.  Otherwise, undefined variables will cause an exception. Defaults to `false`. */
   strictVariables?: boolean;
-  /** Modifies the behavior of `strictVariables`. If set, a single undefined variable will *not* cause an exception in the context of the `if` tag and the `default` filter. Instead, it will evaluate to `false` and `null`, respectively. Irrelevant if `strictVariables` is not set. Defaults to `false`. **/
+  /** Modifies the behavior of `strictVariables`. If set, a single undefined variable will *not* cause an exception in the context of the `if`/`elsif`/`unless` tag and the `default` filter. Instead, it will evaluate to `false` and `null`, respectively. Irrelevant if `strictVariables` is not set. Defaults to `false`. **/
   lenientIf?: boolean;
   /** Strip blank characters (including ` `, `\t`, and `\r`) from the right of tags (`{% %}`) until `\n` (inclusive). Defaults to `false`. */
   trimTagRight?: boolean;

--- a/src/liquid-options.ts
+++ b/src/liquid-options.ts
@@ -19,6 +19,8 @@ export interface LiquidOptions {
   strictFilters?: boolean;
   /** Whether or not to assert variable existence.  If set to `false`, undefined variables will be rendered as empty string.  Otherwise, undefined variables will cause an exception. Defaults to `false`. */
   strictVariables?: boolean;
+  /** Modifies the behavior of `strictVariables`. If set, a single undefined variable will *not* cause an exception in the context of the `if` tag and the `default` filter. Instead, it will evaluate to `false` and `null`, respectively. Irrelevant if `strictVariables` is not set. Defaults to `false`. **/
+  lenientIf?: boolean;
   /** Strip blank characters (including ` `, `\t`, and `\r`) from the right of tags (`{% %}`) until `\n` (inclusive). Defaults to `false`. */
   trimTagRight?: boolean;
   /** Similar to `trimTagRight`, whereas the `\n` is exclusive. Defaults to `false`. See Whitespace Control for details. */
@@ -56,6 +58,7 @@ export interface NormalizedFullOptions extends NormalizedOptions {
   dynamicPartials: boolean;
   strictFilters: boolean;
   strictVariables: boolean;
+  lenientIf: boolean;
   trimTagRight: boolean;
   trimTagLeft: boolean;
   trimOutputRight: boolean;
@@ -85,6 +88,7 @@ export const defaultOptions: NormalizedFullOptions = {
   outputDelimiterRight: '}}',
   strictFilters: false,
   strictVariables: false,
+  lenientIf: false,
   globals: {}
 }
 

--- a/src/render/expression.ts
+++ b/src/render/expression.ts
@@ -12,6 +12,7 @@ import { Context } from '../context/context'
 import { range, toValue } from '../util/underscore'
 import { Tokenizer } from '../parser/tokenizer'
 import { operatorImpls } from '../render/operator'
+import { UndefinedVariableError, InternalUndefinedVariableError } from '../util/error'
 
 export class Expression {
   private operands: any[] = []
@@ -49,12 +50,10 @@ export function evalToken (token: Token | undefined, ctx: Context, lenient: bool
     try {
       return ctx.get([variable, ...props])
     } catch (e) {
-      // for lenient, we catch the error thrown by Context.getFromScope() for undefined vars.
-      // Alt, we could make this more robust by setting a flag or using a separate error class.
-      if (lenient && e instanceof TypeError && e.message.startsWith("undefined variable:")) {
+      if (lenient && e instanceof InternalUndefinedVariableError) {
         return null
       } else {
-        throw(e)
+        throw(new UndefinedVariableError(e, token))
       }
     }
   }

--- a/src/template/value.ts
+++ b/src/template/value.ts
@@ -4,6 +4,7 @@ import { FilterMap } from '../template/filter/filter-map'
 import { Filter } from './filter/filter'
 import { Context } from '../context/context'
 import { ValueToken } from '../tokens/value-token'
+import { assert } from '../util/assert'
 
 export class Value {
   public readonly filters: Filter[] = []
@@ -18,7 +19,10 @@ export class Value {
     this.filters = tokenizer.readFilters().map(({ name, args }) => new Filter(name, this.filterMap.get(name), args))
   }
   public * value (ctx: Context) {
-    let val = yield evalToken(this.initial, ctx)
+    assert(ctx, () => 'unable to evaluate: context not defined')
+    const lenient = ctx.opts.lenientIf && this.filters.length > 0 && this.filters[0].name == "default"
+    
+    let val = yield evalToken(this.initial, ctx, lenient)
     for (const filter of this.filters) {
       val = yield filter.render(val, ctx)
     }

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -48,6 +48,27 @@ export class RenderError extends LiquidError {
   }
 }
 
+export class UndefinedVariableError extends LiquidError {
+  public constructor (err: Error, token: Token) {
+    super(err, token)
+    this.name = 'UndefinedVariableError'
+    this.message = err.message
+    super.update()
+  }
+}
+
+// only used internally; raised where we don't have token information,
+// so it can't be an UndefinedVariableError.
+export class InternalUndefinedVariableError extends Error {
+  variableName: string
+
+  public constructor (variableName: string) {
+    super(`undefined variable: ${variableName}`)
+    this.name = 'InternalUndefinedVariableError'
+    this.variableName = variableName
+  }
+}
+
 export class AssertionError extends Error {
   public constructor (message: string) {
     super(message)

--- a/test/integration/liquid/liquid.ts
+++ b/test/integration/liquid/liquid.ts
@@ -1,4 +1,4 @@
-import { Liquid, isFalsy } from '../../../src/liquid'
+import { Liquid, Context, isFalsy } from '../../../src/liquid'
 import * as chai from 'chai'
 import { mock, restore } from '../../stub/mockfs'
 import * as chaiAsPromised from 'chai-as-promised'
@@ -99,14 +99,16 @@ describe('Liquid', function () {
   describe('#evalValue', function () {
     it('should eval string literal', async function () {
       const engine = new Liquid()
-      const str = await engine.evalValue('"foo"', {} as any)
+      const ctx = new Context()
+      const str = await engine.evalValue('"foo"', ctx)
       expect(str).to.equal('foo')
     })
   })
   describe('#evalValueSync', function () {
     it('should eval string literal', function () {
       const engine = new Liquid()
-      const str = engine.evalValueSync('"foo"', {} as any)
+      const ctx = new Context()
+      const str = engine.evalValueSync('"foo"', ctx)
       expect(str).to.equal('foo')
     })
   })

--- a/test/integration/liquid/strict.ts
+++ b/test/integration/liquid/strict.ts
@@ -45,7 +45,12 @@ describe('LiquidOptions#strict*', function () {
       const html = await engine.render(tpl, {'defined3': 'bla'}, strictLenientOpts)
       return expect(html).to.equal('bla')
     })
-    it('should still throw with an undefined variable in an expression', function () {
+    it('should not throw in `unless` with a single variable', async function () {
+      const tpl = engine.parse('before{% unless notdefined %}X{% else %}{{notdefined}}{% endunless %}after')
+      const html = await engine.render(tpl, ctx, strictLenientOpts)
+      return expect(html).to.equal('beforeXafter')
+    })
+    it('should still throw with an undefined variable in a compound `if` expression', function () {
       const tpl = engine.parse('{% if notdefined == 15 %}a{% endif %}')
       const fhtml = engine.render(tpl, ctx, strictLenientOpts)
       return expect(fhtml).to.be.rejectedWith(/undefined variable: notdefined/)


### PR DESCRIPTION
Resolve #265 

Implemented solution 1 as discussed in the issue. The option is called `lenientIf` (default off).

It's a bit messy because we want to modify behavior only in very specific situations. This is the cleanest I could come up with; hope it's fine.