### PR TITLE
feat: parse and handle date timezone offsets

### DIFF
--- a/src/builtin/filters/date.ts
+++ b/src/builtin/filters/date.ts
@@ -1,4 +1,4 @@
-import strftime from '../../util/strftime'
+import strftime, { TimezoneDate } from '../../util/strftime'
 import { isString, isNumber } from '../../util/underscore'
 
 export function date (v: string | Date, arg: string) {
@@ -8,7 +8,7 @@ export function date (v: string | Date, arg: string) {
   } else if (isNumber(v)) {
     date = new Date(v * 1000)
   } else if (isString(v)) {
-    date = /^\d+$/.test(v) ? new Date(+v * 1000) : new Date(v)
+    date = /^\d+$/.test(v) ? new Date(+v * 1000) : new TimezoneDate(v)
   }
   return isValidDate(date) ? strftime(date, arg) : v
 }

--- a/src/builtin/filters/date.ts
+++ b/src/builtin/filters/date.ts
@@ -1,14 +1,21 @@
 import strftime, { TimezoneDate } from '../../util/strftime'
 import { isString, isNumber } from '../../util/underscore'
+import { FilterImpl } from '../../template/filter/filter-impl'
 
-export function date (v: string | Date, arg: string) {
+export function date (this: FilterImpl, v: string | Date, arg: string) {
   let date = v
   if (v === 'now' || v === 'today') {
     date = new Date()
   } else if (isNumber(v)) {
     date = new Date(v * 1000)
   } else if (isString(v)) {
-    date = /^\d+$/.test(v) ? new Date(+v * 1000) : new TimezoneDate(v)
+    if (/^\d+$/.test(v)) {
+      date = new Date(+v * 1000)
+    } else if (this.context.opts.preserveTimezones) {
+      date = new TimezoneDate(v)
+    } else {
+      date = new Date(v)
+    }
   }
   return isValidDate(date) ? strftime(date, arg) : v
 }

--- a/src/liquid-options.ts
+++ b/src/liquid-options.ts
@@ -37,6 +37,8 @@ export interface LiquidOptions {
   outputDelimiterLeft?: string;
   /** The right delimiter for liquid outputs. **/
   outputDelimiterRight?: string;
+  /** Whether input strings to date filter preserve the given timezone **/
+  preserveTimezones?: boolean;
   /** Whether `trim*Left`/`trim*Right` is greedy. When set to `true`, all consecutive blank characters including `\n` will be trimed regardless of line breaks. Defaults to `true`. */
   greedy?: boolean;
   /** `fs` is used to override the default file-system module with a custom implementation. */
@@ -67,6 +69,7 @@ export interface NormalizedFullOptions extends NormalizedOptions {
   tagDelimiterRight: string;
   outputDelimiterLeft: string;
   outputDelimiterRight: string;
+  preserveTimezones: boolean;
   greedy: boolean;
   globals: object;
 }
@@ -86,6 +89,7 @@ export const defaultOptions: NormalizedFullOptions = {
   tagDelimiterRight: '%}',
   outputDelimiterLeft: '{{',
   outputDelimiterRight: '}}',
+  preserveTimezones: false,
   strictFilters: false,
   strictVariables: false,
   lenientIf: false,

--- a/src/util/strftime.ts
+++ b/src/util/strftime.ts
@@ -143,7 +143,7 @@ const formatCodes = {
 export default function (inputDate: Date, formatStr: string) {
   let d = inputDate
   if (d instanceof TimezoneDate) {
-    d = new Date((+d) + d.inputTimezoneOffset * 60 * 1000)
+    d = d.getDisplayDate()
   }
 
   let output = ''
@@ -189,5 +189,9 @@ export class TimezoneDate extends Date {
       const delta = (sign === '+' ? 1 : -1) * (parseInt(hours, 10) * 60 + parseInt(minutes, 10))
       this.inputTimezoneOffset = this.getTimezoneOffset() + delta
     }
+  }
+
+  getDisplayDate(): Date {
+    return new Date((+this) + this.inputTimezoneOffset * 60 * 1000)
   }
 }

--- a/src/util/strftime.ts
+++ b/src/util/strftime.ts
@@ -177,7 +177,7 @@ function format (d: Date, match: RegExpExecArray) {
 export class TimezoneDate extends Date {
   ISO8601_TIMEZONE_PATTERN = /([zZ]|([+-])(\d{2}):(\d{2}))$/;
 
-  inputTimezoneOffset: number = 0;
+  inputTimezoneOffset = 0;
 
   constructor (public dateString: string) {
     super(dateString)
@@ -185,13 +185,13 @@ export class TimezoneDate extends Date {
     if (m && m[1] === 'Z') {
       this.inputTimezoneOffset = this.getTimezoneOffset()
     } else if (m && m[2] && m[3] && m[4]) {
-      const [, , sign, hours, minutes] = m;
+      const [, , sign, hours, minutes] = m
       const delta = (sign === '+' ? 1 : -1) * (parseInt(hours, 10) * 60 + parseInt(minutes, 10))
       this.inputTimezoneOffset = this.getTimezoneOffset() + delta
     }
   }
 
-  getDisplayDate(): Date {
+  getDisplayDate (): Date {
     return new Date((+this) + this.inputTimezoneOffset * 60 * 1000)
   }
 }

--- a/test/integration/builtin/filters/date.ts
+++ b/test/integration/builtin/filters/date.ts
@@ -11,19 +11,19 @@ describe('filters/date', function () {
   it('should create a new Date when given "today"', function () {
     return test('{{ "today" | date: "%Y"}}', (new Date()).getFullYear().toString())
   })
-  it('should parse as Date when given UTC string', function () {
+  it('should parse as Date when given a timezoneless string', function () {
     return test('{{ "1991-02-22T00:00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1991-02-22T00:00:00')
   })
   it('should not change the timezone between input and output', function () {
     return test('{{ "1990-12-31T23:00:00Z" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
   })
-  it('should apply numeric offset', function () {
+  it('should apply numeric timezone offset (0)', function () {
     return test('{{ "1990-12-31T23:00:00+00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
   })
-  it('should apply numeric offset', function () {
+  it('should apply numeric timezone offset (-1)', function () {
     return test('{{ "1990-12-31T23:00:00-01:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
   })
-  it('should apply numeric offset', function () {
+  it('should apply numeric timezone offset (+2.30)', function () {
     return test('{{ "1990-12-31T23:00:00+02:30" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
   })
   it('should render string as string if not valid', function () {

--- a/test/integration/builtin/filters/date.ts
+++ b/test/integration/builtin/filters/date.ts
@@ -1,3 +1,4 @@
+import { LiquidOptions } from '../../../../src/liquid-options'
 import { test } from '../../../stub/render'
 
 describe('filters/date', function () {
@@ -14,17 +15,21 @@ describe('filters/date', function () {
   it('should parse as Date when given a timezoneless string', function () {
     return test('{{ "1991-02-22T00:00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1991-02-22T00:00:00')
   })
-  it('should not change the timezone between input and output', function () {
-    return test('{{ "1990-12-31T23:00:00Z" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
-  })
-  it('should apply numeric timezone offset (0)', function () {
-    return test('{{ "1990-12-31T23:00:00+00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
-  })
-  it('should apply numeric timezone offset (-1)', function () {
-    return test('{{ "1990-12-31T23:00:00-01:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
-  })
-  it('should apply numeric timezone offset (+2.30)', function () {
-    return test('{{ "1990-12-31T23:00:00+02:30" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
+  describe('when preserveTimezones is enabled', function () {
+    const opts: LiquidOptions = { preserveTimezones: true };
+
+    it('should not change the timezone between input and output', function () {
+      return test('{{ "1990-12-31T23:00:00Z" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00', undefined, opts)
+    })
+    it('should apply numeric timezone offset (0)', function () {
+      return test('{{ "1990-12-31T23:00:00+00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00', undefined, opts)
+    })
+    it('should apply numeric timezone offset (-1)', function () {
+      return test('{{ "1990-12-31T23:00:00-01:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00', undefined, opts)
+    })
+    it('should apply numeric timezone offset (+2.30)', function () {
+      return test('{{ "1990-12-31T23:00:00+02:30" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00', undefined, opts)
+    })
   })
   it('should render string as string if not valid', function () {
     return test('{{ "foo" | date: "%Y"}}', 'foo')

--- a/test/integration/builtin/filters/date.ts
+++ b/test/integration/builtin/filters/date.ts
@@ -12,7 +12,19 @@ describe('filters/date', function () {
     return test('{{ "today" | date: "%Y"}}', (new Date()).getFullYear().toString())
   })
   it('should parse as Date when given UTC string', function () {
-    return test('{{ "1991-02-22T00:00:00" | date: "%Y"}}', '1991')
+    return test('{{ "1991-02-22T00:00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1991-02-22T00:00:00')
+  })
+  it('should not change the timezone between input and output', function () {
+    return test('{{ "1990-12-31T23:00:00Z" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
+  })
+  it('should apply numeric offset', function () {
+    return test('{{ "1990-12-31T23:00:00+00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
+  })
+  it('should apply numeric offset', function () {
+    return test('{{ "1990-12-31T23:00:00-01:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
+  })
+  it('should apply numeric offset', function () {
+    return test('{{ "1990-12-31T23:00:00+02:30" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00')
   })
   it('should render string as string if not valid', function () {
     return test('{{ "foo" | date: "%Y"}}', 'foo')

--- a/test/integration/builtin/filters/date.ts
+++ b/test/integration/builtin/filters/date.ts
@@ -16,7 +16,7 @@ describe('filters/date', function () {
     return test('{{ "1991-02-22T00:00:00" | date: "%Y-%m-%dT%H:%M:%S"}}', '1991-02-22T00:00:00')
   })
   describe('when preserveTimezones is enabled', function () {
-    const opts: LiquidOptions = { preserveTimezones: true };
+    const opts: LiquidOptions = { preserveTimezones: true }
 
     it('should not change the timezone between input and output', function () {
       return test('{{ "1990-12-31T23:00:00Z" | date: "%Y-%m-%dT%H:%M:%S"}}', '1990-12-31T23:00:00', undefined, opts)

--- a/test/stub/render.ts
+++ b/test/stub/render.ts
@@ -1,16 +1,17 @@
 import { Liquid } from '../../src/liquid'
+import { LiquidOptions } from '../../src/liquid-options'
 import { expect } from 'chai'
 
 export const liquid = new Liquid()
 
-export function render (src: string, ctx?: object) {
-  return liquid.parseAndRender(src, ctx)
+export function render (src: string, ctx?: object, opts?: LiquidOptions) {
+  return liquid.parseAndRender(src, ctx, opts)
 }
 
-export async function test (src: string, ctx: object | string, dst?: string) {
+export async function test (src: string, ctx: object | string, dst?: string, opts?: LiquidOptions) {
   if (dst === undefined) {
     dst = ctx as string
     ctx = {}
   }
-  return expect(await render(src, ctx as object)).to.equal(dst)
+  return expect(await render(src, ctx as object, opts)).to.equal(dst)
 }


### PR DESCRIPTION
Adds timezone offset parsing (e.g. `1990-12-31T23:00:00+02:00`) and mangling the pre-format date object to the right timestamp.

I'm not sure if it even makes sense for this to go in as is, because to me the default behavior of formatting timezoned dates to the local timezone automatically makes sense most of the time in web context: e.g. blogs might usually want to show dates in user-local format. However, configuring timezone preservation in the liquid filter is also a bit weird, since for instance in node.js we will probably always want to preserve the timezone.

What about configuring this in liquid-options?

(eventually) fixes #236 