### PR TITLE
Promise support in liquidMethodMissing & expressions

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -67,9 +67,12 @@ export class Context {
   }
 }
 
-export function readProperty (obj: Scope, key: string) {
+export function readProperty (obj: Scope, key: string) : any {
   if (isNil(obj)) return obj
   obj = toLiquid(obj)
+  if (obj instanceof Promise) {
+    return obj.then(resolvedObj=>readProperty(resolvedObj, key))
+  }
   if (obj instanceof Drop) {
     if (isFunction(obj[key])) return obj[key]()
     if (obj.hasOwnProperty(key)) return obj[key]

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -67,7 +67,7 @@ export class Context {
   }
 }
 
-export function readProperty (obj: Scope, key: string) : any {
+export function readProperty (obj: Scope, key: string): any {
   if (isNil(obj)) return obj
   obj = toLiquid(obj)
   if (obj instanceof Promise) {

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -71,7 +71,7 @@ export function readProperty (obj: Scope, key: string) : any {
   if (isNil(obj)) return obj
   obj = toLiquid(obj)
   if (obj instanceof Promise) {
-    return obj.then(resolvedObj=>readProperty(resolvedObj, key))
+    return obj.then(resolvedObj => readProperty(resolvedObj, key))
   }
   if (obj instanceof Drop) {
     if (isFunction(obj[key])) return obj[key]()

--- a/src/drop/drop.ts
+++ b/src/drop/drop.ts
@@ -3,7 +3,7 @@ export abstract class Drop {
     return undefined
   }
 
-  public liquidMethodMissing (key: string): Promise<any | undefined> | string | undefined {
+  public liquidMethodMissing (key: string): Promise<any | undefined> | any | undefined {
     return undefined
   }
 }

--- a/src/drop/drop.ts
+++ b/src/drop/drop.ts
@@ -3,7 +3,7 @@ export abstract class Drop {
     return undefined
   }
 
-  public liquidMethodMissing (key: string): Promise<string | undefined> | string | undefined {
+  public liquidMethodMissing (key: string): Promise<any | undefined> | string | undefined {
     return undefined
   }
 }

--- a/src/render/expression.ts
+++ b/src/render/expression.ts
@@ -24,11 +24,11 @@ export class Expression {
     this.postfix = [...toPostfix(tokenizer.readExpression())]
     this.lenient = lenient
   }
-  public evaluate (ctx: Context): any {
+  public * evaluate (ctx: Context): any {
     for (const token of this.postfix) {
       if (TypeGuards.isOperatorToken(token)) {
-        const r = this.operands.pop()
-        const l = this.operands.pop()
+        const r = yield this.operands.pop()
+        const l = yield this.operands.pop()
         const result = evalOperatorToken(token, l, r, ctx)
         this.operands.push(result)
       } else {
@@ -38,7 +38,7 @@ export class Expression {
     return this.operands[0]
   }
   public * value (ctx: Context) {
-    return toValue(this.evaluate(ctx))
+    return toValue(yield this.evaluate(ctx))
   }
 }
 

--- a/test/integration/builtin/tags/if.ts
+++ b/test/integration/builtin/tags/if.ts
@@ -64,6 +64,12 @@ describe('tags/if', function () {
       const html = await liquid.parseAndRender(src, scope)
       return expect(html).to.equal('XY')
     })
+    it('should evaluate promise', async function () {
+      const src = `{%if var == 'var' %}success{%endif%}`
+      const scope = { 'var': Promise.resolve('var') }
+      const html = await liquid.parseAndRender(src, scope)
+      return expect(html).to.equal('success')
+    })
     it('should evaluate right to left', async function () {
       const src = `{% if false and false or true %}true{%endif%}`
       const html = await liquid.parseAndRender(src)

--- a/test/integration/drop/drop.ts
+++ b/test/integration/drop/drop.ts
@@ -25,6 +25,11 @@ describe('drop/drop', function () {
       return key.toUpperCase()
     }
   }
+  class PromiseDropWithPromiseMethodMissing extends Drop {
+    public async liquidMethodMissing (key: string) {
+      return Promise.resolve(key.toUpperCase())
+    }
+  }
   it('should call corresponding method when output', async function () {
     const html = await liquid.parseAndRender(`{{obj.getName}}`, { obj: new CustomDrop() })
     expect(html).to.equal('GET NAME')
@@ -51,6 +56,10 @@ describe('drop/drop', function () {
   })
   it('should read corresponding promise property', async function () {
     const html = await liquid.parseAndRender(`{{obj.name}}`, { obj: new PromiseDrop() })
+    expect(html).to.equal('NAME')
+  })
+  it('should read corresponding liquidMethodMissing promise', async function () {
+    const html = await liquid.parseAndRender(`{{obj.name}}`, { obj: new PromiseDropWithPromiseMethodMissing() })
     expect(html).to.equal('NAME')
   })
   it('should resolve before calling filters', async function () {


### PR DESCRIPTION
adds a promise support in liquidMethodMissing. This should extends Drop capability. Should fix #274 

Also, adds a promise support in expressions. Should address #276  

This is my first pull request, i ran the tests and all passed.


