### PR TITLE
fix: default to precedence 1 for custom operators

### DIFF
--- a/src/tokens/operator-token.ts
+++ b/src/tokens/operator-token.ts
@@ -25,6 +25,7 @@ export class OperatorToken extends Token {
     this.operator = this.getText()
   }
   getPrecedence () {
-    return precedence[this.getText()]
+    const key = this.getText()
+    return key in precedence ? precedence[key] : 1
   }
 }

--- a/test/integration/liquid/operators-option.ts
+++ b/test/integration/liquid/operators-option.ts
@@ -24,4 +24,11 @@ describe('LiquidOptions#operators', function () {
     const second = await engine.parseAndRender('{% if "foo" isFooBar "foo" %}True{% else %}False{% endif %}')
     expect(second).to.equal('False')
   })
+
+  it('should evaluate a custom operator with the correct precedence', async function () {
+    const first = await engine.parseAndRender('{% if "foo" isFooBar "bar" or "foo" == "bar" %}True{% else %}False{% endif %}')
+    expect(first).to.equal('True')
+    const second = await engine.parseAndRender('{% if "foo" isFooBar "foo" or "foo" == "bar" %}True{% else %}False{% endif %}')
+    expect(second).to.equal('False')
+  })
 })


### PR DESCRIPTION
This fixes a small bug with custom operators introduced in #301; the `precedence` object helped to define when an operator was passed the literal value vs. a boolean. `0` is meant for `and/or`, and `1` for every other comparator - but custom operators would receive a value of `undefined`, which evaluated to falsy. This meant that custom operators wouldn't get the expected arguments:

```
{% if "foo" isFooBar "bar" or "foo" == "bar" %}True{% else %}False{% endif %}
```

`isFooBar` would receive:

```js
function isFooBar (l, r) {
  console.log(l, r)
  // => "foo", false
}
```

This PR falls back to a precedence of `1` for any token that isn't explicitly hard-coded (the default operators). Technically, this limits the functionality of custom operators but I think that's a reasonable tradeoff; I can't think of a kind of custom operator that would _need_ a precedence of `0`.

I've added a test for this behavior - it fails without the change to `src/tokens/operator-token.ts`, and passes with it 🎉 