### PR TITLE
feat: export errors for better error handling in user-land

### DIFF
--- a/src/liquid.ts
+++ b/src/liquid.ts
@@ -15,6 +15,7 @@ import { FilterImplOptions } from './template/filter/filter-impl-options'
 import { toPromise, toValue } from './util/async'
 import { Emitter } from './render/emitter'
 
+export * from './util/error'
 export * from './types'
 
 export class Liquid {

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -2,7 +2,7 @@ import * as _ from './underscore'
 import { Token } from '../tokens/token'
 import { Template } from '../template/template'
 
-abstract class LiquidError extends Error {
+export abstract class LiquidError extends Error {
   private token: Token
   private originalError: Error
   public constructor (err: Error, token: Token) {


### PR DESCRIPTION
This exports the errors, so `instanceof LiquidError` checks can be done in user-land.