### PR TITLE
fix: make LiquidError context property public

### DIFF
--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -4,7 +4,7 @@ import { Template } from '../template/template'
 
 export abstract class LiquidError extends Error {
   private token: Token
-  private context: string
+  public context: string
   private originalError: Error
   public constructor (err: Error, token: Token) {
     super(err.message)


### PR DESCRIPTION
Follow-up for https://github.com/harttle/liquidjs/pull/338 as I accidentally declared the context property as private...