### PR TITLE
feat: when tag with multiple values

### DIFF
--- a/docs/source/tags/case.md
+++ b/docs/source/tags/case.md
@@ -12,7 +12,7 @@ Input
 {% case handle %}
   {% when "cake" %}
      This is a cake
-  {% when "cookie" %}
+  {% when "cookie", "biscuit" %}
      This is a cookie
   {% else %}
      This is not a cake nor a cookie

--- a/docs/source/zh-cn/tags/case.md
+++ b/docs/source/zh-cn/tags/case.md
@@ -12,7 +12,7 @@ title: case
 {% case handle %}
   {% when "cake" %}
      This is a cake
-  {% when "cookie" %}
+  {% when "cookie", "biscuit" %}
      This is a cookie
   {% else %}
      This is not a cake nor a cookie

--- a/test/integration/builtin/tags/case.ts
+++ b/test/integration/builtin/tags/case.ts
@@ -64,4 +64,11 @@ describe('tags/case', function () {
       return expect(html).to.equal('d')
     })
   })
+  it('should support case with multiple values', async function () {
+    const src = '{% case "b" %}' +
+            '{% when "a", "b" %}foo' +
+            '{%endcase%}'
+    const html = await liquid.parseAndRender(src)
+    return expect(html).to.equal('foo')
+  })
 })


### PR DESCRIPTION
Add support for when tag with multiple values, like described in the [Shopify's liquid documentation](https://shopify.github.io/liquid/tags/control-flow/#casewhen):

Input:

```
{% assign handle = "cake" %}
{% case handle %}
  {% when "cake" %}
     This is a cake
  {% when "cookie", "biscuit" %}
     This is a cookie
  {% else %}
     This is not a cake nor a cookie
{% endcase %}
```

Output:

```
This is a cake
```