### PR TITLE
Boost perf

### DIFF
--- a/benchmark/engines/liquid.js
+++ b/benchmark/engines/liquid.js
@@ -4,6 +4,7 @@ const { join } = require('path')
 
 const liquid = new Liquid({
   root: join(__dirname, '../templates'),
+  cache: true,
   extname: '.liquid'
 })
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,8 @@
   "scripts": {
     "lint": "eslint \"**/*.ts\" .",
     "check": "npm test && npm run lint",
-    "unit": "mocha \"test/unit/**/*.ts\"",
-    "integration": "mocha \"test/integration/**/*.ts\"",
-    "e2e": "mocha \"test/e2e/**/*.ts\"",
     "test": "nyc mocha \"test/**/*.ts\"",
-    "benchmark:prepare": "cd benchmark && npm ci",
-    "benchmark": "cd benchmark && npm start",
-    "benchmark:engines": "cd benchmark && npm run engines",
+    "benchmark": "cd benchmark && npm ci && npm start",
     "build": "npm run build:dist && npm run build:docs",
     "build:dist": "rm -rf dist && rollup -c rollup.config.ts && ls -lh dist",
     "build:docs": "bin/build-docs.sh"

--- a/src/builtin/tags/include.ts
+++ b/src/builtin/tags/include.ts
@@ -37,7 +37,7 @@ export default {
     ctx.setRegister('blockMode', BlockMode.OUTPUT)
     const scope = yield hash.render(ctx)
     if (withVar) scope[filepath] = evalToken(withVar, ctx)
-    const templates = yield liquid._parseFile(filepath, ctx.opts, ctx.sync)
+    const templates = yield liquid.parseFileImpl(filepath, ctx.sync)
     ctx.push(scope)
     yield renderer.renderTemplates(templates, ctx, emitter)
     ctx.pop()

--- a/src/builtin/tags/layout.ts
+++ b/src/builtin/tags/layout.ts
@@ -26,7 +26,7 @@ export default {
         : evalToken(this.file, ctx))
       : file.getText()
     assert(filepath, () => `file "${file.getText()}"("${filepath}") not available`)
-    const templates = yield liquid._parseFile(filepath, ctx.opts, ctx.sync)
+    const templates = yield liquid.parseFileImpl(filepath, ctx.sync)
 
     // render remaining contents and store rendered results
     ctx.setRegister('blockMode', BlockMode.STORE)

--- a/src/builtin/tags/layout.ts
+++ b/src/builtin/tags/layout.ts
@@ -1,31 +1,27 @@
-import { assert, evalQuotedToken, TypeGuards, evalToken, Tokenizer, Emitter, Hash, TagToken, TopLevelToken, Context, TagImplOptions } from '../../types'
+import { assert, Tokenizer, Emitter, Hash, TagToken, TopLevelToken, Context, TagImplOptions } from '../../types'
 import BlockMode from '../../context/block-mode'
+import { parseFilePath, renderFilePath } from './render'
 
 export default {
+  parseFilePath,
+  renderFilePath,
   parse: function (token: TagToken, remainTokens: TopLevelToken[]) {
     const tokenizer = new Tokenizer(token.args, this.liquid.options.operatorsTrie)
-    const file = this.liquid.options.dynamicPartials ? tokenizer.readValue() : tokenizer.readFileName()
-    assert(file, () => `illegal argument "${token.args}"`)
-
-    this.file = file
+    this['file'] = this.parseFilePath(tokenizer, this.liquid)
     this.hash = new Hash(tokenizer.remaining())
     this.tpls = this.liquid.parser.parse(remainTokens)
   },
   render: function * (ctx: Context, emitter: Emitter) {
     const { liquid, hash, file } = this
     const { renderer } = liquid
-    if (file.getText() === 'none') {
+    if (file === null) {
       ctx.setRegister('blockMode', BlockMode.OUTPUT)
       const html = yield renderer.renderTemplates(this.tpls, ctx)
       emitter.write(html)
       return
     }
-    const filepath = ctx.opts.dynamicPartials
-      ? (TypeGuards.isQuotedToken(file)
-        ? yield renderer.renderTemplates(liquid.parse(evalQuotedToken(file)), ctx)
-        : evalToken(this.file, ctx))
-      : file.getText()
-    assert(filepath, () => `file "${file.getText()}"("${filepath}") not available`)
+    const filepath = yield this.renderFilePath(this['file'], ctx, liquid)
+    assert(filepath, () => `illegal filename "${filepath}"`)
     const templates = yield liquid.parseFileImpl(filepath, ctx.sync)
 
     // render remaining contents and store rendered results

--- a/src/builtin/tags/render.ts
+++ b/src/builtin/tags/render.ts
@@ -64,12 +64,12 @@ export default {
       scope['forloop'] = new ForloopDrop(collection.length)
       for (const item of collection) {
         scope[alias] = item
-        const templates = yield liquid._parseFile(filepath, childCtx.opts, childCtx.sync)
+        const templates = yield liquid.parseFileImpl(filepath, childCtx.sync)
         yield renderer.renderTemplates(templates, childCtx, emitter)
         scope.forloop.next()
       }
     } else {
-      const templates = yield liquid._parseFile(filepath, childCtx.opts, childCtx.sync)
+      const templates = yield liquid.parseFileImpl(filepath, childCtx.sync)
       yield renderer.renderTemplates(templates, childCtx, emitter)
     }
   }

--- a/src/parser/tokenizer.ts
+++ b/src/parser/tokenizer.ts
@@ -31,7 +31,7 @@ export class Tokenizer {
   private rawBeginAt = -1
 
   constructor (
-    private input: string,
+    public input: string,
     private trie: Trie,
     private file: string = ''
   ) {

--- a/src/render/emitter.ts
+++ b/src/render/emitter.ts
@@ -14,7 +14,7 @@ export class Emitter {
     if (this.keepOutputType === true) {
       html = toValue(html)
     } else {
-      html = stringify(toValue(html))
+      html = stringify(html)
     }
     // This will only preserve the type if the value is isolated.
     // I.E:

--- a/src/render/expression.ts
+++ b/src/render/expression.ts
@@ -47,10 +47,9 @@ export function evalToken (token: Token | undefined, ctx: Context, lenient = fal
 }
 
 function evalPropertyAccessToken (token: PropertyAccessToken, ctx: Context, lenient: boolean) {
-  const variable = token.getVariableAsText()
   const props: string[] = token.props.map(prop => evalToken(prop, ctx, false))
   try {
-    return ctx.get([variable, ...props])
+    return ctx.get([token.propertyName, ...props])
   } catch (e) {
     if (lenient && e.name === 'InternalUndefinedVariableError') return null
     throw (new UndefinedVariableError(e, token))

--- a/src/tokens/property-access-token.ts
+++ b/src/tokens/property-access-token.ts
@@ -5,19 +5,15 @@ import { TokenKind } from '../parser/token-kind'
 import { parseStringLiteral } from '../parser/parse-string-literal'
 
 export class PropertyAccessToken extends Token {
+  public propertyName: string
   constructor (
     public variable: IdentifierToken | QuotedToken,
     public props: (IdentifierToken | QuotedToken | PropertyAccessToken)[],
     end: number
   ) {
     super(TokenKind.PropertyAccess, variable.input, variable.begin, end, variable.file)
-  }
-
-  getVariableAsText () {
-    if (this.variable instanceof IdentifierToken) {
-      return this.variable.getText()
-    } else {
-      return parseStringLiteral(this.variable.getText())
-    }
+    this.propertyName = this.variable instanceof IdentifierToken
+      ? this.variable.getText()
+      : parseStringLiteral(this.variable.getText())
   }
 }

--- a/src/util/underscore.ts
+++ b/src/util/underscore.ts
@@ -3,13 +3,8 @@ import { Drop } from '../drop/drop'
 const toStr = Object.prototype.toString
 const toLowerCase = String.prototype.toLowerCase
 
-/*
- * Checks if value is classified as a String primitive or object.
- * @param {any} value The value to check.
- * @return {Boolean} Returns true if value is a string, else false.
- */
 export function isString (value: any): value is string {
-  return toStr.call(value) === '[object String]'
+  return typeof value === 'string'
 }
 
 export function isFunction (value: any): value is Function {
@@ -30,7 +25,9 @@ export function promisify (fn: any) {
 
 export function stringify (value: any): string {
   value = toValue(value)
-  return isNil(value) ? '' : String(value)
+  if (isString(value)) return value
+  if (isNil(value)) return ''
+  return String(value)
 }
 
 export function toValue (value: any): any {
@@ -47,7 +44,7 @@ export function toLiquid (value: any): any {
 }
 
 export function isNil (value: any): boolean {
-  return value === null || value === undefined
+  return value == null
 }
 
 export function isArray (value: any): value is any[] {

--- a/test/integration/builtin/tags/include.ts
+++ b/test/integration/builtin/tags/include.ts
@@ -44,7 +44,7 @@ describe('tags/include', function () {
     })
     return liquid.renderFile('/parent.html').catch(function (e) {
       expect(e.name).to.equal('RenderError')
-      expect(e.message).to.match(/illegal filename "not-exist"/)
+      expect(e.message).to.match(/illegal filename "undefined"/)
     })
   })
 

--- a/test/integration/builtin/tags/layout.ts
+++ b/test/integration/builtin/tags/layout.ts
@@ -38,7 +38,7 @@ describe('tags/layout', function () {
     })
     return liquid.renderFile('/parent.html').catch(function (e) {
       expect(e.name).to.equal('RenderError')
-      expect(e.message).to.contain('file "foo"("undefined") not available')
+      expect(e.message).to.contain('illegal filename "undefined"')
     })
   })
   it('should handle layout none', async function () {

--- a/test/integration/builtin/tags/render.ts
+++ b/test/integration/builtin/tags/render.ts
@@ -44,7 +44,7 @@ describe('tags/render', function () {
     })
     return liquid.renderFile('/parent.html').catch(function (e) {
       expect(e.name).to.equal('RenderError')
-      expect(e.message).to.match(/illegal filename "not-exist":"undefined"/)
+      expect(e.message).to.match(/illegal filename "undefined"/)
     })
   })
 

--- a/test/integration/builtin/tags/render.ts
+++ b/test/integration/builtin/tags/render.ts
@@ -76,15 +76,12 @@ describe('tags/render', function () {
   })
 
   it('should be able to access globals', async function () {
+    liquid = new Liquid({ root: '/', extname: '.html', globals: { name: 'Harttle' } })
     mock({
       '/hash.html': 'InParent: {{name}} {% render "user.html" %}',
       '/user.html': 'InChild: {{name}}'
     })
-    const html = await liquid.renderFile('hash.html', {
-      name: 'harttle'
-    }, {
-      globals: { name: 'Harttle' }
-    })
+    const html = await liquid.renderFile('hash', { name: 'harttle' })
     expect(html).to.equal('InParent: harttle InChild: Harttle')
   })
 

--- a/test/integration/liquid/cache.ts
+++ b/test/integration/liquid/cache.ts
@@ -132,34 +132,6 @@ describe('LiquidOptions#cache', function () {
       const y = await engine.renderFile('foo')
       expect(y).to.equal('foo')
     })
-    it('should respect passed in cache=false option', async function () {
-      const engine = new Liquid({
-        root: '/root/',
-        extname: '.html',
-        cache: true
-      })
-      mock({ '/root/files/foo.html': 'foo' })
-      const x = await engine.renderFile('files/foo')
-      expect(x).to.equal('foo')
-      mock({ '/root/files/foo.html': 'bar' })
-      const y = await engine.renderFile('files/foo')
-      expect(y).to.equal('foo')
-      const z = await engine.renderFile('files/foo', undefined, { cache: false })
-      expect(z).to.equal('bar')
-    })
-    it('should use cache when passing in other options', async function () {
-      const engine = new Liquid({
-        root: '/root/',
-        extname: '.html',
-        cache: true
-      })
-      mock({ '/root/files/foo.html': 'foo' })
-      const x = await engine.renderFile('files/foo')
-      expect(x).to.equal('foo')
-      mock({ '/root/files/foo.html': 'bar' })
-      const y = await engine.renderFile('files/foo', undefined, { greedy: true })
-      expect(y).to.equal('foo')
-    })
   })
 
   describe('#renderFileSync', function () {
@@ -200,34 +172,6 @@ describe('LiquidOptions#cache', function () {
 
       mock({ '/root/foo.html': 'foo' })
       const y = await engine.renderFile('foo')
-      expect(y).to.equal('foo')
-    })
-    it('should respect passed in cache=false option', async function () {
-      const engine = new Liquid({
-        root: '/root/',
-        extname: '.html',
-        cache: true
-      })
-      mock({ '/root/files/foo.html': 'foo' })
-      const x = engine.renderFileSync('files/foo')
-      expect(x).to.equal('foo')
-      mock({ '/root/files/foo.html': 'bar' })
-      const y = engine.renderFileSync('files/foo')
-      expect(y).to.equal('foo')
-      const z = engine.renderFileSync('files/foo', undefined, { cache: false })
-      expect(z).to.equal('bar')
-    })
-    it('should use cache when passing in other options', async function () {
-      const engine = new Liquid({
-        root: '/root/',
-        extname: '.html',
-        cache: true
-      })
-      mock({ '/root/files/foo.html': 'foo' })
-      const x = engine.renderFileSync('files/foo')
-      expect(x).to.equal('foo')
-      mock({ '/root/files/foo.html': 'bar' })
-      const y = engine.renderFileSync('files/foo', undefined, { greedy: true })
       expect(y).to.equal('foo')
     })
   })

--- a/test/integration/liquid/liquid.ts
+++ b/test/integration/liquid/liquid.ts
@@ -91,7 +91,7 @@ describe('Liquid', function () {
         root: ['/root/'],
         extname: '.html'
       })
-      const tpls = await engine.getTemplate('mocha')
+      const tpls = await engine.parseFileSync('mocha')
       expect(tpls.length).to.gte(1)
       expect(tpls[0].token.getText()).to.contain('module.exports')
     })
@@ -126,7 +126,7 @@ describe('Liquid', function () {
         root: ['/boo', '/root/'],
         extname: '.html'
       })
-      return expect(() => engine.getTemplateSync('/not/exist.html'))
+      return expect(() => engine.parseFileSync('/not/exist.html'))
         .to.throw(/Failed to lookup "\/not\/exist.html" in "\/boo,\/root\/"/)
     })
   })

--- a/test/integration/liquid/strict.ts
+++ b/test/integration/liquid/strict.ts
@@ -20,53 +20,61 @@ describe('LiquidOptions#strict*', function () {
   })
   it('should throw when strictVariables true', function () {
     const tpl = engine.parse('before{{notdefined}}after')
-    const opts = {
+    engine = new Liquid({
+      root: '/root/',
+      extname: '.html',
       strictVariables: true
-    }
-    return expect(engine.render(tpl, ctx, opts)).to
+    })
+    return expect(engine.render(tpl, ctx)).to
       .be.rejectedWith(/undefined variable: notdefined/)
   })
   it('should pass strictVariables to render by parseAndRender', function () {
     const html = 'before{{notdefined}}after'
-    const opts = {
+    engine = new Liquid({
+      root: '/root/',
+      extname: '.html',
       strictVariables: true
-    }
-    return expect(engine.parseAndRender(html, ctx, opts)).to
+    })
+    return expect(engine.parseAndRender(html, ctx)).to
       .be.rejectedWith(/undefined variable: notdefined/)
   })
   describe('with strictVariables and lenientIf', function () {
-    const strictLenientOpts = {
-      strictVariables: true,
-      lenientIf: true
-    }
+    beforeEach(() => {
+      engine = new Liquid({
+        root: '/root/',
+        extname: '.html',
+        strictVariables: true,
+        lenientIf: true
+      })
+    })
     it('should not throw in `if` with a single variable', async function () {
       const tpl = engine.parse('before{% if notdefined %}{{notdefined}}{% endif %}after')
-      const html = await engine.render(tpl, ctx, strictLenientOpts)
+      const html = await engine.render(tpl, ctx)
       return expect(html).to.equal('beforeafter')
     })
     it('should support elsif with undefined variables', async function () {
       const tpl = engine.parse('{% if notdefined1 %}a{% elsif notdefined2 %}b{% elsif defined3 %}{{defined3}}{% else %}d{% endif %}')
-      const html = await engine.render(tpl, { 'defined3': 'bla' }, strictLenientOpts)
+      const html = await engine.render(tpl, { 'defined3': 'bla' })
       return expect(html).to.equal('bla')
     })
     it('should not throw in `unless` with a single variable', async function () {
       const tpl = engine.parse('before{% unless notdefined %}X{% else %}{{notdefined}}{% endunless %}after')
-      const html = await engine.render(tpl, ctx, strictLenientOpts)
+      const html = await engine.render(tpl, ctx)
       return expect(html).to.equal('beforeXafter')
     })
     it('should still throw with an undefined variable in a compound `if` expression', function () {
       const tpl = engine.parse('{% if notdefined == 15 %}a{% endif %}')
-      const fhtml = engine.render(tpl, ctx, strictLenientOpts)
+      const fhtml = engine.render(tpl, ctx)
       return expect(fhtml).to.be.rejectedWith(/undefined variable: notdefined/)
     })
     it('should allow an undefined variable when before the `default` filter', async function () {
       const tpl = engine.parse('{{notdefined | default: "a" | tolower}}')
-      const html = await engine.render(tpl, ctx, strictLenientOpts)
+      const html = await engine.render(tpl, ctx)
       return expect(html).to.equal('a')
     })
     it('should not allow undefined variable even if `lenientIf` set', async function () {
       const tpl = engine.parse('{{notdefined | tolower}}')
-      return expect(() => engine.renderSync(tpl, ctx, strictLenientOpts)).to.throw('undefined variable: notdefined')
+      return expect(() => engine.renderSync(tpl, ctx)).to.throw('undefined variable: notdefined')
     })
   })
 })

--- a/test/integration/util/error.ts
+++ b/test/integration/util/error.ts
@@ -269,9 +269,8 @@ describe('error', function () {
         .to.throw(RenderError, /intended render error/)
     })
     it('should contain original error info for {% include %}', function () {
-      const origin = ['1st', '2nd', '3rd', 'X{%throwingTag%} Y', '5th', '6th', '7th']
       mock({
-        '/throwing-tag.html': origin.join('\n')
+        '/throwing-tag.html': ['1st', '2nd', '3rd', 'X{%throwingTag%} Y', '5th', '6th', '7th'].join('\n')
       })
       const html = '{%include "throwing-tag.html"%}'
       const message = [

--- a/test/stub/render.ts
+++ b/test/stub/render.ts
@@ -4,8 +4,8 @@ import { expect } from 'chai'
 
 export const liquid = new Liquid()
 
-export function render (src: string, ctx?: object, opts?: LiquidOptions) {
-  return liquid.parseAndRender(src, ctx, opts)
+export function render (src: string, ctx?: object) {
+  return liquid.parseAndRender(src, ctx)
 }
 
 export async function test (src: string, ctx: object | string, dst?: string, opts?: LiquidOptions) {
@@ -13,5 +13,6 @@ export async function test (src: string, ctx: object | string, dst?: string, opt
     dst = ctx as string
     ctx = {}
   }
-  return expect(await render(src, ctx as object, opts)).to.equal(dst)
+  const engine = opts ? new Liquid(opts) : liquid
+  return expect(await engine.parseAndRender(src, ctx as object)).to.equal(dst)
 }

--- a/test/unit/tokens/property-access-token.ts
+++ b/test/unit/tokens/property-access-token.ts
@@ -8,14 +8,14 @@ chai.use(sinonChai)
 const expect = chai.expect
 
 describe('PropertyAccessToken', function () {
-  describe('getVariableAsText', function () {
+  describe('#propertyName', function () {
     it('should return correct value for IdentifierToken', function () {
       const token = new PropertyAccessToken(new IdentifierToken('foo', 0, 3), [], 3)
-      expect(token.getVariableAsText()).to.equal('foo')
+      expect(token.propertyName).to.equal('foo')
     })
     it('should return correct value for QuotedToken', function () {
       const token = new PropertyAccessToken(new QuotedToken('"foo bar"', 0, 9), [], 9)
-      expect(token.getVariableAsText()).to.equal('foo bar')
+      expect(token.propertyName).to.equal('foo bar')
     })
   })
 })


### PR DESCRIPTION
* parse filenames in parse() instead of render() if applicable
* postpone `resolve()` for partial fallback
* use file specifier instead of resolved filepath as cache key

Before this update (50x slower than Handlebars, even slower than React):

```
➜  benchmark git:(refs/heads/master) npm run engines
> benchmark@1.0.0 engines
> node -e 'require("./cross-engines").crossEngines()'
liquid x 788 ops/sec ±1.94% (89 runs sampled)
handlebars x 36,930 ops/sec ±1.07% (91 runs sampled)
react x 4,449 ops/sec ±2.37% (86 runs sampled)
swig x 53,257 ops/sec ±0.77% (92 runs sampled)
```

After this update (3x slower than Handlebars, 3x faster than React):

```
➜  benchmark git:(refs/heads/master) npm run engines
> benchmark@1.0.0 engines
> node -e 'require("./cross-engines").crossEngines()'
liquid x 12,311 ops/sec ±1.27% (90 runs sampled)
handlebars x 36,997 ops/sec ±1.31% (87 runs sampled)
react x 4,418 ops/sec ±3.08% (87 runs sampled)
swig x 50,481 ops/sec ±2.81% (87 runs sampled)
```