### PR TITLE
feat: support iteration protocols

### DIFF
--- a/src/util/collection.ts
+++ b/src/util/collection.ts
@@ -1,8 +1,9 @@
-import { isNil, isString, isObject, isArray } from './underscore'
+import { isNil, isString, isObject, isArray, isIterable } from './underscore'
 
 export function toEnumerable (val: any) {
   if (isArray(val)) return val
   if (isString(val) && val.length > 0) return [val]
+  if (isIterable(val)) return Array.from(val)
   if (isObject(val)) return Object.keys(val).map((key) => [key, val[key]])
   return []
 }

--- a/src/util/underscore.ts
+++ b/src/util/underscore.ts
@@ -60,6 +60,10 @@ export function isArray (value: any): value is any[] {
   return toString.call(value) === '[object Array]'
 }
 
+export function isIterable (value: any): value is Iterable<any> {
+  return isObject(value) && Symbol.iterator in value
+}
+
 /*
  * Iterates over own enumerable string keyed properties of an object and invokes iteratee for each property.
  * The iteratee is invoked with three arguments: (value, key, object).

--- a/test/integration/builtin/tags/render.ts
+++ b/test/integration/builtin/tags/render.ts
@@ -155,6 +155,20 @@ describe('tags/render', function () {
     const html = await liquid.renderFile('index.html', { colors: ['red', 'green'] })
     expect(html).to.equal('1: red\n2: green\n')
   })
+  it('should support for <iterable> as', async function () {
+    class MockIterable {
+      * [Symbol.iterator] () {
+        yield 'red'
+        yield 'green'
+      }
+    }
+    mock({
+      '/index.html': '{% render "item" for colors as color %}',
+      '/item.html': '{{forloop.index}}: {{color}}\n'
+    })
+    const html = await liquid.renderFile('index.html', { colors: new MockIterable() })
+    expect(html).to.equal('1: red\n2: green\n')
+  })
   it('should support for <non-array> as', async function () {
     mock({
       '/index.html': '{% render "item" for "green" as color %}',

--- a/test/integration/builtin/tags/tablerow.ts
+++ b/test/integration/builtin/tags/tablerow.ts
@@ -24,6 +24,23 @@ describe('tags/tablerow', function () {
     return expect(html).to.equal(dst)
   })
 
+  it('should support iterables', async function () {
+    class MockIterable {
+      * [Symbol.iterator] () {
+        yield 1
+        yield 2
+        yield 3
+      }
+    }
+    const src = '{% tablerow i in someIterable %}{{ i }}{% endtablerow %}'
+    const ctx = {
+      someIterable: new MockIterable()
+    }
+    const dst = '<tr class="row1"><td class="col1">1</td><td class="col2">2</td><td class="col3">3</td></tr>'
+    const html = await liquid.parseAndRender(src, ctx)
+    return expect(html).to.equal(dst)
+  })
+
   it('should support cols', async function () {
     const src = '{% tablerow i in alpha cols:2 %}{{ i }}{% endtablerow %}'
     const ctx = {


### PR DESCRIPTION
This pull request adds support for looping over objects implementing JavaScript's [iteration protocols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) in Liquid `for`, `render` and `tablerow` tags. It is also a potential solution to issue #515, without changing the behaviour of `Drop.valueOf()`.

Note that this means we can loop over [Maps](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Sets](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set), as well as user-defined iterables.

**Example**
```js
const { Liquid } = require("liquidjs");
const engine = new Liquid();

class SomeIterable {
  * [Symbol.iterator]() {
    yield 'a'
    yield 'b'
    yield 'c'
  }
}

engine
  .parseAndRender(
    "{% for i in someIterable %}{{ i }}{{ endfor }}",
    {someIterable: new SomeIterable()})
  .then(console.log);
```

**Output**
```text
abc
```

Or an iterable `Drop` that can display a user friendly string if output directly.

**Example**
```js
const { Liquid, Drop } = require("liquidjs");
const engine = new Liquid();

class SomeIterableDrop extends Drop {
  constructor() {
    this.someArray = [1,2,3];
  }

  [Symbol.iterator]() {
    return this.someArray[Symbol.iterator]();
  }

  valueOf() {
    return "SomeIterableDrop";
  }
}

engine
  .parseAndRender(
    "{{ someDrop }}: {% for i in someDrop %}{{ i }} {{ endfor }}",
    {someDrop: new SomeIterableDrop()})
  .then(console.log);
```

**Output**
```text
SomeIterableDrop: 1 2 3
```
