### PR TITLE
feat: remove_last and replace_last filters

### DIFF
--- a/docs/source/filters/remove_last.md
+++ b/docs/source/filters/remove_last.md
@@ -1,0 +1,17 @@
+---
+title: remove_last
+---
+
+{% since %}v10.2.0{% endsince %}
+
+Removes only the last occurrence of the specified substring from a string.
+
+Input
+```liquid
+{{ "I strained to see the train through the rain" | remove_last: "rain" }}
+```
+
+Output
+```text
+I strained to see the train through the
+```

--- a/docs/source/filters/replace_last.md
+++ b/docs/source/filters/replace_last.md
@@ -1,0 +1,17 @@
+---
+title: replace_last
+---
+
+{% since %}v10.2.0{% endsince %}
+
+Replaces only the last occurrence of the first argument in a string with the second argument.
+
+Input
+```liquid
+{{ "Take my protein pills and put my helmet on" | replace_last: "my", "your" }}
+```
+
+Output
+```text
+Take my protein pills and put your helmet on
+```

--- a/src/filters/string.ts
+++ b/src/filters/string.ts
@@ -82,6 +82,15 @@ export function replace_first (v: string, arg1: string, arg2: string) {
   return stringify(v).replace(String(arg1), arg2)
 }
 
+export function replace_last (v: string, arg1: string, arg2: string) {
+  const str = stringify(v)
+  const pattern = String(arg1)
+  const index = str.lastIndexOf(pattern)
+  if (index === -1) return str
+  const replacement = String(arg2)
+  return str.substring(0, index) + replacement + str.substring(index + pattern.length)
+}
+
 export function truncate (v: string, l = 50, o = '...') {
   v = stringify(v)
   if (v.length <= l) return v

--- a/src/filters/string.ts
+++ b/src/filters/string.ts
@@ -39,6 +39,14 @@ export function remove_first (v: string, l: string) {
   return stringify(v).replace(String(l), '')
 }
 
+export function remove_last (v: string, l: string) {
+  const str = stringify(v)
+  const pattern = String(l)
+  const index = str.lastIndexOf(pattern)
+  if (index === -1) return str
+  return str.substring(0, index) + str.substring(index + pattern.length + 1)
+}
+
 export function rstrip (str: string, chars?: string) {
   if (chars) {
     chars = escapeRegExp(stringify(chars))

--- a/test/integration/filters/string.ts
+++ b/test/integration/filters/string.ts
@@ -202,13 +202,23 @@ describe('filters/string', function () {
       return test('{{ "1 2 3 4 5 6 7 8 9 a b c d e f" | truncatewords }}', '1 2 3 4 5 6 7 8 9 a b c d e f...')
     })
   })
+  describe('remove_last', function () {
+    it('should remove the last occurrence of substring', function () {
+      return test('{{ "I strained to see the train through the rain" | remove_last: "rain" }}',
+        'I strained to see the train through the ')
+    })
+    it('should handle substring not found', function () {
+      return test('{{ "I strained to see the train through the rain" | remove_last: "no such thing" }}',
+        'I strained to see the train through the rain')
+    })
+  })
   describe('replace_last', function () {
     it('should replace the last occurrence of substring', function () {
       return test('{{ "Take my protein pills and put my helmet on" | replace_last: "my", "your" }}',
         'Take my protein pills and put your helmet on')
     })
     it('should handle substring not found', function () {
-      return test('{{ "Take my protein pills and put my helmet on" | replace_last: "nosuchthing", "your" }}',
+      return test('{{ "Take my protein pills and put my helmet on" | replace_last: "no such thing", "your" }}',
         'Take my protein pills and put my helmet on')
     })
   })

--- a/test/integration/filters/string.ts
+++ b/test/integration/filters/string.ts
@@ -202,4 +202,14 @@ describe('filters/string', function () {
       return test('{{ "1 2 3 4 5 6 7 8 9 a b c d e f" | truncatewords }}', '1 2 3 4 5 6 7 8 9 a b c d e f...')
     })
   })
+  describe('replace_last', function () {
+    it('should replace the last occurrence of substring', function () {
+      return test('{{ "Take my protein pills and put my helmet on" | replace_last: "my", "your" }}',
+        'Take my protein pills and put your helmet on')
+    })
+    it('should handle substring not found', function () {
+      return test('{{ "Take my protein pills and put my helmet on" | replace_last: "nosuchthing", "your" }}',
+        'Take my protein pills and put my helmet on')
+    })
+  })
 })


### PR DESCRIPTION
This pull request adds the `remove_last` and `replace_last` filters to LiquidJS. These filters were added to [Shopify/liquid](https://github.com/Shopify/liquid/blob/master/History.md#520-2022-03-01) in version 5.2.0.