### PR TITLE
feat: forloop's parentloop

### DIFF
--- a/docs/source/tags/for.md
+++ b/docs/source/tags/for.md
@@ -127,7 +127,7 @@ Last
 The `forloop.index`, `forloop.index0`, `forloop.rindex` and `forloop.rindex0` property:
 
 Input
-```
+```liquid
 index index0 rindex rindex0
 {% for i in (1..5) %}
   {{- forloop.index }}     {{ forloop.index0 }}      {{ forloop.rindex }}      {{ forloop.rindex0 }}
@@ -142,6 +142,27 @@ index index0 rindex rindex0
 3     2      3      2
 4     3      2      1
 5     4      1      0
+```
+
+The `forloop.parentloop` property is available when `for` loops are nested:
+
+Input
+```liquid
+index parentloop.index
+{% for i in (1..2) -%}
+  {% for j in (3..4) -%}
+    {{ forloop.index }}     {{ forloop.parentloop.index }}
+  {% endfor -%}
+{% endfor -%}
+```
+
+Output
+```
+index parentloop.index
+1     1
+2     1
+1     2
+2     2
 ```
 
 ## Parameters

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -39,8 +39,8 @@ export class Context {
     this.environments = env
     this.strictVariables = renderOptions.strictVariables ?? this.opts.strictVariables
   }
-  public getRegister (key: string, defaultValue?: any) {
-    return (this.registers[key] = this.registers[key] || (defaultValue ?? {}))
+  public getRegister (key: string, defaultValue = {}) {
+    return (this.registers[key] = this.registers[key] || defaultValue)
   }
   public setRegister (key: string, value: any) {
     return (this.registers[key] = value)

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -39,8 +39,8 @@ export class Context {
     this.environments = env
     this.strictVariables = renderOptions.strictVariables ?? this.opts.strictVariables
   }
-  public getRegister (key: string) {
-    return (this.registers[key] = this.registers[key] || {})
+  public getRegister (key: string, defaultValue?: any) {
+    return (this.registers[key] = this.registers[key] || (defaultValue ?? {}))
   }
   public setRegister (key: string, value: any) {
     return (this.registers[key] = value)

--- a/src/drop/forloop-drop.ts
+++ b/src/drop/forloop-drop.ts
@@ -6,11 +6,11 @@ export class ForloopDrop extends Drop {
   public name: string
   public length: number
   public parentloop: ForloopDrop | NullDrop
-  public constructor (length: number, collection: string, variable: string, parentloop?: ForloopDrop) {
+  public constructor (length: number, collection: string, variable: string, parentloop: ForloopDrop|NullDrop = NULL) {
     super()
     this.length = length
     this.name = `${variable}-${collection}`
-    this.parentloop = parentloop ?? NULL
+    this.parentloop = parentloop
   }
   public next () {
     this.i++

--- a/src/drop/forloop-drop.ts
+++ b/src/drop/forloop-drop.ts
@@ -1,13 +1,16 @@
 import { Drop } from './drop'
+import { NULL, NullDrop } from './null-drop'
 
 export class ForloopDrop extends Drop {
   protected i = 0
   public name: string
   public length: number
-  public constructor (length: number, collection: string, variable: string) {
+  public parentloop: ForloopDrop | NullDrop
+  public constructor (length: number, collection: string, variable: string, parentloop?: ForloopDrop) {
     super()
     this.length = length
     this.name = `${variable}-${collection}`
+    this.parentloop = parentloop ?? NULL
   }
   public next () {
     this.i++

--- a/src/drop/null-drop.ts
+++ b/src/drop/null-drop.ts
@@ -22,3 +22,5 @@ export class NullDrop extends Drop implements Comparable {
     return null
   }
 }
+
+export const NULL = new NullDrop()

--- a/src/drop/null-drop.ts
+++ b/src/drop/null-drop.ts
@@ -21,6 +21,9 @@ export class NullDrop extends Drop implements Comparable {
   public valueOf () {
     return null
   }
+  public toJSON () {
+    return null
+  }
 }
 
 export const NULL = new NullDrop()

--- a/src/tags/for.ts
+++ b/src/tags/for.ts
@@ -1,7 +1,6 @@
 import { Hash, ValueToken, Liquid, Tag, Tokenizer, evalToken, Emitter, TagToken, TopLevelToken, Context, Template, ParseStream } from '..'
 import { toEnumerable } from '../util/collection'
 import { ForloopDrop } from '../drop/forloop-drop'
-import { NULL } from '../drop'
 
 const MODIFIERS = ['offset', 'limit', 'reversed']
 
@@ -69,7 +68,7 @@ export default class extends Tag {
     ctx.setRegister(continueKey, (hash['offset'] || 0) + collection.length)
 
     const forloopRegister = ctx.getRegister('forloops', [])
-    const parentloop = forloopRegister[forloopRegister.length - 1] ?? NULL
+    const parentloop = forloopRegister[forloopRegister.length - 1]
     const drop = new ForloopDrop(collection.length, this.collection.getText(), this.variable, parentloop)
     const scope = { forloop: drop }
 


### PR DESCRIPTION
This pull request implements the `parentloop` property of a `for` tag's `forloop` drop. `forloop.parentloop` was added to [Shopify/liquid version 4.0](https://github.com/Shopify/liquid/blob/master/History.md#400--2016-12-14--branch-4-0-stable).

Quoting from the Shopify/liquid [docs](https://shopify.github.io/liquid/tags/iteration/), `forloop.parentloop` is:

> The parent forloop object. If the current for loop isn’t nested inside another for loop, then nil is returned.