### PR TITLE
ownPropertyOnly not respected when passed via renderOptions

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -38,6 +38,7 @@ export class Context {
     this.globals = renderOptions.globals ?? opts.globals
     this.environments = env
     this.strictVariables = renderOptions.strictVariables ?? this.opts.strictVariables
+    this.opts.ownPropertyOnly = renderOptions.ownPropertyOnly ?? opts.ownPropertyOnly
   }
   public getRegister (key: string) {
     return (this.registers[key] = this.registers[key] || {})


### PR DESCRIPTION
When passing `ownPropertyOnly` via `renderOptions`, it is ignored, even though it's included in the RenderOptions Typescript signature.