### PR TITLE
Update differences.md

### DIFF
--- a/docs/source/tutorials/differences.md
+++ b/docs/source/tutorials/differences.md
@@ -30,7 +30,6 @@ Though we're trying to be compatible with the Ruby version, there are still some
 * Sort stability. The [sort][sort] stability is also not defined in both shopify/liquid and LiquidJS, but it's [considered stable][stable-sort] for LiquidJS in Node.js 12+ and Google Chrome 70+.
 * Trailing unmatched characters inside filters are allowed in shopify/liquid but not in LiquidJS. It means filter arguments without a colon like `{%raw%}{{ "a b" | split " "}}{%endraw%}` will throw an error in LiquidJS. This is intended to improve Liquid usability, see [#208][#208] and [#212][#212].
 * LiquidJS has additional tags: [layout][layout] and corresponding `block` tag.
-* LiquidJS has additional filters: [json][json].
 * LiquidJS [date][date] filter supports `%q` for date ordinals like `{{ '2023/02/02' | date: '%d%q of %b'}}` => `02nd of Feb`
 
 [date]: https://liquidjs.com/filters/date.html


### PR DESCRIPTION
## Summary
- Shopify also has `json` filter, I think it is equivalent to liquidJS `json`
- See https://shopify.dev/docs/api/liquid/filters/json

## Propose changes
- Remove the line `* LiquidJS has additional filters: [json][json].` from the doc