### PR TITLE
test: Add tests for `push`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+1. Build everything and run tests to learn how to do both:
+  - `npm run build`
+  - `npm run test`
+
+  Tests won't at first unless you've done a build at least once.
+  Subsequent changes to tests do not need re-builds but changes to the code and
+  then tests need a build to pick up the new code by the tests.
+
+2. Make your changes and add a test for them
+  - Build after you've made your changes
+  - Run tests as per the above to validate your changes
+
+3. Create a pull request
+  - Ensure the build runs because the Husky pre-commit hook checks it
+  - `git switch -c your_branch_name` (do this in your fork not the main repo)
+  - `git add .`
+  - `git commit -m "feat: Adding my change"`
+  - `git push`
+  - Go to GitHub and find your fork, open a PR against the upstream from it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 1. Build everything and run tests to learn how to do both:
-  - `npm run build`
+  - `npm run build:dist`
   - `npm run test`
 
   Tests won't at first unless you've done a build at least once.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 1. Build everything and run tests to learn how to do both:
-  - `npm run build:dist`
+  - `npm run build`
   - `npm run test`
 
   Tests won't at first unless you've done a build at least once.
@@ -14,6 +14,16 @@
 
 3. Create a pull request
   - Ensure the build runs because the Husky pre-commit hook checks it
+    - `npm run check` checks runs the build, tests, lint and perf tests
+    - `commitlint` checks the commit message format
+    
+    If there is a problem you will see it in the pre-commit hook output.
+    In VS Code, this output will be shown in a new file in a new tab if the
+    pre-commit hook fails.
+    If you want to check the commit message without using the VS Code Source
+    Control UI, you can run `echo "feat: my commit message" > npx commitlint`
+    directly.
+    
   - `git switch -c your_branch_name` (do this in your fork not the main repo)
   - `git add .`
   - `git commit -m "feat: Adding my change"`

--- a/src/filters/array.ts
+++ b/src/filters/array.ts
@@ -88,14 +88,3 @@ export function uniq<T> (arr: T[]): T[] {
     return true
   })
 }
-
-export function sample<T> (v: T[] | string, count: number | undefined = undefined): T[] | string {
-  v = toValue(v)
-  if (isNil(v)) return []
-  if (!isArray(v)) {
-    v = stringify(v)
-    return [...v].sort(() => Math.random() ).slice(0, count).join('')
-  }
-
-  return [...v].sort(() => Math.random() ).slice(0, count)
-}

--- a/src/filters/array.ts
+++ b/src/filters/array.ts
@@ -88,3 +88,14 @@ export function uniq<T> (arr: T[]): T[] {
     return true
   })
 }
+
+export function sample<T> (v: T[] | string, count: number | undefined = undefined): T[] | string {
+  v = toValue(v)
+  if (isNil(v)) return []
+  if (!isArray(v)) {
+    v = stringify(v)
+    return [...v].sort(() => Math.random() ).slice(0, count).join('')
+  }
+
+  return [...v].sort(() => Math.random() ).slice(0, count)
+}

--- a/test/integration/filters/array.spec.ts
+++ b/test/integration/filters/array.spec.ts
@@ -92,6 +92,27 @@ describe('filters/array', function () {
     })
   })
 
+  describe('push', () => {
+    it('should push arg value', async () => {
+      const scope = { val: ['hey'], arg: 'foo' }
+      await test('{{ val | push: arg | join: "," }}', scope, 'hey,foo')
+    })
+    it('should support undefined left value', async () => {
+      const scope = { arg: 'foo' }
+      await test('{{ notDefined | push: arg | join: "," }}', scope, 'foo')
+    })
+    it('should ignore nil left value', async () => {
+      const scope = { undefinedValue: undefined, nullValue: null, arg: 'foo' }
+      await test('{{ undefinedValue | push: arg | join: "," }}', scope, 'foo')
+      await test('{{ nullValue | push: arg | join: "," }}', scope, 'foo')
+    })
+    it('should ignore nil right value', async () => {
+      const scope = { nullValue: null }
+      await test('{{ nullValue | push | join: "," }}', scope, '')
+      await test('{{ nullValue | push: nil | join: "," }}', scope, '')
+    })
+  })
+
   describe('reverse', function () {
     it('should support reverse', () => test(
       '{{ "Ground control to Major Tom." | split: "" | reverse | join: "" }}',


### PR DESCRIPTION
I thought `push` was broken because it doesn't work on the Playground but that's not the case. Here are the tests to prove it. Taken from the `concat` tests.

Related to #611 