### PR TITLE
fix: sed invocations to work out of the box on macOS

### DIFF
--- a/bin/build-changelog.sh
+++ b/bin/build-changelog.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    alias sedi="sed -i ''"
-else
-    alias sedi="sed -i"
-fi
+# Run `sed` in a way that's compatible with both macOS (BSD) and Linux (GNU)
+sedi() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
 
 cd docs
 cp ../CHANGELOG.md source/tutorials/changelog.md

--- a/bin/build-changelog.sh
+++ b/bin/build-changelog.sh
@@ -20,12 +20,7 @@ sedi \
   source/tutorials/changelog.md
 cp source/tutorials/changelog.md source/zh-cn/tutorials/changelog.md
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' -e '1i\
+sedi -e '1i\
  ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
-  sed -i '' -e '1i\
+sedi -e '1i\
  ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
-else
-  sed -i '1i ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
-  sed -i '1i ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
-fi

--- a/bin/build-changelog.sh
+++ b/bin/build-changelog.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 
+REPLACE_START_RAW='s/{%/{% raw %}{%{% endraw %}/g'
+REPLACE_END_RAW='s/{{/{% raw %}{{{% endraw %}/g'
+ESCAPE_QUOT='1 s/"/\&quot;/g'
+ESCAPE_LT='1 s/</\&lt;/g'
+ESCAPE_GT='1 s/>/\&gt;/g'
+
 cd docs
 cp ../CHANGELOG.md source/tutorials/changelog.md
-sed -i '' \
-  -e 's/{%/{% raw %}{%{% endraw %}/g' \
-  -e 's/{{/{% raw %}{{{% endraw %}/g' \
-  -e '1 s/"/\&quot;/g' \
-  -e '1 s/</\&lt;/g' \
-  -e '1 s/>/\&gt;/g' \
-  source/tutorials/changelog.md
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -e "$REPLACE_START_RAW" -e "$REPLACE_END_RAW" -e "$ESCAPE_QUOT" -e "$ESCAPE_LT" -e "$ESCAPE_GT" source/tutorials/changelog.md
+else
+    sed -i -e "$REPLACE_START_RAW" -e "$REPLACE_END_RAW" -e "$ESCAPE_QUOT" -e "$ESCAPE_LT" -e "$ESCAPE_GT" source/tutorials/changelog.md
+fi
 cp source/tutorials/changelog.md source/zh-cn/tutorials/changelog.md
 
-sed -i '' \
-  -e '1i\
- ---\ntitle: Changelog\nauto: true\n---\n' \
-  source/tutorials/changelog.md
-
-sed -i '' \
-  -e '1i\
- ---\ntitle: 更新日志\nauto: true\n---\n' \
-  source/zh-cn/tutorials/changelog.md
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -e '1i\
+ ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
+    sed -i '' -e '1i\
+ ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
+else
+    sed -i '1i ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
+    sed -i '1i ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
+fi

--- a/bin/build-changelog.sh
+++ b/bin/build-changelog.sh
@@ -2,30 +2,30 @@
 
 # Run `sed` in a way that's compatible with both macOS (BSD) and Linux (GNU)
 sedi() {
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "$@"
-    else
-        sed -i "$@"
-    fi
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
 }
 
 cd docs
 cp ../CHANGELOG.md source/tutorials/changelog.md
 sedi \
-    -e 's/{%/{% raw %}{%{% endraw %}/g' \
-    -e 's/{{/{% raw %}{{{% endraw %}/g' \
-    -e '1 s/"/\&quot;/g' \
-    -e '1 s/</\&lt;/g' \
-    -e '1 s/>/\&gt;/g' \
-    source/tutorials/changelog.md
+  -e 's/{%/{% raw %}{%{% endraw %}/g' \
+  -e 's/{{/{% raw %}{{{% endraw %}/g' \
+  -e '1 s/"/\&quot;/g' \
+  -e '1 s/</\&lt;/g' \
+  -e '1 s/>/\&gt;/g' \
+  source/tutorials/changelog.md
 cp source/tutorials/changelog.md source/zh-cn/tutorials/changelog.md
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' -e '1i\
+  sed -i '' -e '1i\
  ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
-    sed -i '' -e '1i\
+  sed -i '' -e '1i\
  ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
 else
-    sed -i '1i ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
-    sed -i '1i ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
+  sed -i '1i ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
+  sed -i '1i ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
 fi

--- a/bin/build-changelog.sh
+++ b/bin/build-changelog.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 
-REPLACE_START_RAW='s/{%/{% raw %}{%{% endraw %}/g'
-REPLACE_END_RAW='s/{{/{% raw %}{{{% endraw %}/g'
-ESCAPE_QUOT='1 s/"/\&quot;/g'
-ESCAPE_LT='1 s/</\&lt;/g'
-ESCAPE_GT='1 s/>/\&gt;/g'
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    alias sedi="sed -i ''"
+else
+    alias sedi="sed -i"
+fi
 
 cd docs
 cp ../CHANGELOG.md source/tutorials/changelog.md
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' -e "$REPLACE_START_RAW" -e "$REPLACE_END_RAW" -e "$ESCAPE_QUOT" -e "$ESCAPE_LT" -e "$ESCAPE_GT" source/tutorials/changelog.md
-else
-    sed -i -e "$REPLACE_START_RAW" -e "$REPLACE_END_RAW" -e "$ESCAPE_QUOT" -e "$ESCAPE_LT" -e "$ESCAPE_GT" source/tutorials/changelog.md
-fi
+sedi \
+    -e 's/{%/{% raw %}{%{% endraw %}/g' \
+    -e 's/{{/{% raw %}{{{% endraw %}/g' \
+    -e '1 s/"/\&quot;/g' \
+    -e '1 s/</\&lt;/g' \
+    -e '1 s/>/\&gt;/g' \
+    source/tutorials/changelog.md
 cp source/tutorials/changelog.md source/zh-cn/tutorials/changelog.md
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/bin/build-changelog.sh
+++ b/bin/build-changelog.sh
@@ -2,7 +2,7 @@
 
 cd docs
 cp ../CHANGELOG.md source/tutorials/changelog.md
-sed -i \
+sed -i '' \
   -e 's/{%/{% raw %}{%{% endraw %}/g' \
   -e 's/{{/{% raw %}{{{% endraw %}/g' \
   -e '1 s/"/\&quot;/g' \
@@ -11,5 +11,12 @@ sed -i \
   source/tutorials/changelog.md
 cp source/tutorials/changelog.md source/zh-cn/tutorials/changelog.md
 
-sed -i '1i ---\ntitle: Changelog\nauto: true\n---\n' source/tutorials/changelog.md
-sed -i '1i ---\ntitle: 更新日志\nauto: true\n---\n' source/zh-cn/tutorials/changelog.md
+sed -i '' \
+  -e '1i\
+ ---\ntitle: Changelog\nauto: true\n---\n' \
+  source/tutorials/changelog.md
+
+sed -i '' \
+  -e '1i\
+ ---\ntitle: 更新日志\nauto: true\n---\n' \
+  source/zh-cn/tutorials/changelog.md

--- a/bin/build-contributors.sh
+++ b/bin/build-contributors.sh
@@ -2,18 +2,18 @@
 
 # Run `sed` in a way that's compatible with both macOS (BSD) and Linux (GNU)
 sedi() {
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "$@"
-    else
-        sed -i "$@"
-    fi
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
 }
 
 cp .all-contributorsrc docs/.all-contributorsrc
 sedi \
-    -e 's/README.md/docs\/themes\/navy\/layout\/partial\/all-contributors.swig/g' \
-    -e 's/"contributorsPerLine": 7/"contributorsPerLine": 65535/g' \
-    docs/.all-contributorsrc
+  -e 's/README.md/docs\/themes\/navy\/layout\/partial\/all-contributors.swig/g' \
+  -e 's/"contributorsPerLine": 7/"contributorsPerLine": 65535/g' \
+  docs/.all-contributorsrc
 
 all-contributors --config docs/.all-contributorsrc generate
 sedi 's/<br \/>.*<\/td>/<\/a><\/td>/g' docs/themes/navy/layout/partial/all-contributors.swig

--- a/bin/build-contributors.sh
+++ b/bin/build-contributors.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
+REPLACE_README_MD='s/README.md/docs\/themes\/navy\/layout\/partial\/all-contributors.swig/g'
+REPLACE_CONTRIBUTORS_PER_LINE='s/"contributorsPerLine": 7/"contributorsPerLine": 65535/g'
+REPLACE_CONTRIBUTOR_LINKS='s/<br \/>.*<\/td>/<\/a><\/td>/g'
+
 cp .all-contributorsrc docs/.all-contributorsrc
-sed -i '' \
-    -e 's/README.md/docs\/themes\/navy\/layout\/partial\/all-contributors.swig/g' \
-    -e 's/"contributorsPerLine": 7/"contributorsPerLine": 65535/g' \
-    docs/.all-contributorsrc
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -e "$REPLACE_README_MD" -e "$REPLACE_CONTRIBUTORS_PER_LINE" docs/.all-contributorsrc
+else
+    sed -i -e "$REPLACE_README_MD" -e "$REPLACE_CONTRIBUTORS_PER_LINE" docs/.all-contributorsrc
+fi
 
 all-contributors --config docs/.all-contributorsrc generate
-sed -i '' \
-    -e 's/<br \/>.*<\/td>/<\/a><\/td>/g' docs/themes/navy/layout/partial/all-contributors.swig
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -e "$REPLACE_CONTRIBUTOR_LINKS" docs/themes/navy/layout/partial/all-contributors.swig
+else
+    sed -i "$REPLACE_CONTRIBUTOR_LINKS" docs/themes/navy/layout/partial/all-contributors.swig
+fi

--- a/bin/build-contributors.sh
+++ b/bin/build-contributors.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 
-REPLACE_README_MD='s/README.md/docs\/themes\/navy\/layout\/partial\/all-contributors.swig/g'
-REPLACE_CONTRIBUTORS_PER_LINE='s/"contributorsPerLine": 7/"contributorsPerLine": 65535/g'
-REPLACE_CONTRIBUTOR_LINKS='s/<br \/>.*<\/td>/<\/a><\/td>/g'
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    alias sedi="sed -i ''"
+else
+    alias sedi="sed -i"
+fi
 
 cp .all-contributorsrc docs/.all-contributorsrc
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' -e "$REPLACE_README_MD" -e "$REPLACE_CONTRIBUTORS_PER_LINE" docs/.all-contributorsrc
-else
-    sed -i -e "$REPLACE_README_MD" -e "$REPLACE_CONTRIBUTORS_PER_LINE" docs/.all-contributorsrc
-fi
+sedi \
+    -e 's/README.md/docs\/themes\/navy\/layout\/partial\/all-contributors.swig/g' \
+    -e 's/"contributorsPerLine": 7/"contributorsPerLine": 65535/g' \
+    docs/.all-contributorsrc
 
 all-contributors --config docs/.all-contributorsrc generate
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' -e "$REPLACE_CONTRIBUTOR_LINKS" docs/themes/navy/layout/partial/all-contributors.swig
-else
-    sed -i "$REPLACE_CONTRIBUTOR_LINKS" docs/themes/navy/layout/partial/all-contributors.swig
-fi
+sedi 's/<br \/>.*<\/td>/<\/a><\/td>/g' docs/themes/navy/layout/partial/all-contributors.swig

--- a/bin/build-contributors.sh
+++ b/bin/build-contributors.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    alias sedi="sed -i ''"
-else
-    alias sedi="sed -i"
-fi
+# Run `sed` in a way that's compatible with both macOS (BSD) and Linux (GNU)
+sedi() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
 
 cp .all-contributorsrc docs/.all-contributorsrc
 sedi \

--- a/bin/build-contributors.sh
+++ b/bin/build-contributors.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 cp .all-contributorsrc docs/.all-contributorsrc
-sed -i \
+sed -i '' \
     -e 's/README.md/docs\/themes\/navy\/layout\/partial\/all-contributors.swig/g' \
     -e 's/"contributorsPerLine": 7/"contributorsPerLine": 65535/g' \
     docs/.all-contributorsrc
 
 all-contributors --config docs/.all-contributorsrc generate
-sed -i 's/<br \/>.*<\/td>/<\/a><\/td>/g' docs/themes/navy/layout/partial/all-contributors.swig
+sed -i '' \
+    -e 's/<br \/>.*<\/td>/<\/a><\/td>/g' docs/themes/navy/layout/partial/all-contributors.swig


### PR DESCRIPTION
These fixes make the sed invocations run on macOS but I am not sure if they will break the GNU sed invocations in return… I am hoping the GitHub Actions workflow will pass and config this is now portable between macOS and Ubuntu (what GitHub Actions is using).