### PR TITLE
fix: remove_last was eating an extra character

### DIFF
--- a/src/filters/string.ts
+++ b/src/filters/string.ts
@@ -44,7 +44,7 @@ export function remove_last (v: string, l: string) {
   const pattern = String(l)
   const index = str.lastIndexOf(pattern)
   if (index === -1) return str
-  return str.substring(0, index) + str.substring(index + pattern.length + 1)
+  return str.substring(0, index) + str.substring(index + pattern.length)
 }
 
 export function rstrip (str: string, chars?: string) {

--- a/test/integration/filters/string.spec.ts
+++ b/test/integration/filters/string.spec.ts
@@ -203,6 +203,10 @@ describe('filters/string', function () {
       return test('{{ "I strained to see the train through the rain" | remove_last: "rain" }}',
         'I strained to see the train through the ')
     })
+    it('should remove the last occurrence of substring in the middle of a string', function () {
+      return test('{{ "I strained to see the train through the rain and fog" | remove_last: "rain" }}',
+        'I strained to see the train through the  and fog')
+    })
     it('should handle substring not found', function () {
       return test('{{ "I strained to see the train through the rain" | remove_last: "no such thing" }}',
         'I strained to see the train through the rain')


### PR DESCRIPTION
When the substring to remove was anywhere but the end of the larger string, `remove_last` would eat an extra character. 