### PR TITLE
docs: fix options link in setup tutorial

### DIFF
--- a/docs/source/tutorials/setup.md
+++ b/docs/source/tutorials/setup.md
@@ -100,4 +100,4 @@ Most of the [options available through the JavaScript API][options] are also ava
 A ReactJS demo is also added by [@stevenanthonyrevo](https://github.com/stevenanthonyrevo), see [liquidjs/demo/reactjs/](https://github.com/harttle/liquidjs/blob/master/demo/reactjs/).
 
 [intro]: ./intro-to-liquid.html
-[options]: ./options.md
+[options]: ./options.html


### PR DESCRIPTION
Given in the published version, https://liquidjs.com/tutorials/options.md doesn't exist