### PR TITLE
fix: case should allow multiple values separated by or

### DIFF
--- a/src/tags/case.ts
+++ b/src/tags/case.ts
@@ -17,7 +17,12 @@ export default class extends Tag {
         const values: ValueToken[] = []
         while (!token.tokenizer.end()) {
           values.push(token.tokenizer.readValueOrThrow())
-          token.tokenizer.readTo(',')
+          token.tokenizer.skipBlank()
+          if (token.tokenizer.peek() === ',') {
+            token.tokenizer.readTo(',')
+          } else {
+            token.tokenizer.readTo('or')
+          }
         }
         this.branches.push({
           values,

--- a/test/integration/tags/case.spec.ts
+++ b/test/integration/tags/case.spec.ts
@@ -75,4 +75,20 @@ describe('tags/case', function () {
     const html = await liquid.parseAndRender(src)
     return expect(html).toBe('firstsecond')
   })
+  it('should support case with multiple values separated by or', async function () {
+    const src = '{% case 3 %}' +
+            '{% when 1 or 2 or 3 %}1 or 2 or 3' +
+            '{% else %}not 1 or 2 or 3' +
+            '{%endcase%}'
+    const html = await liquid.parseAndRender(src)
+    return expect(html).toBe('1 or 2 or 3')
+  })
+  it('should support case with multiple strings separated by or', async function () {
+    const src = '{% case "or" %}' +
+            '{% when "and" or "or" %}and or or' +
+            '{% else %}not and or or' +
+            '{%endcase%}'
+    const html = await liquid.parseAndRender(src)
+    return expect(html).toBe('and or or')
+  })
 })


### PR DESCRIPTION
This is supported by Shopify liquid.