### PR TITLE
fix: handle windows/dos newlines on `newline_to_br` and `strip_newlines`

### DIFF
--- a/src/filters/html.ts
+++ b/src/filters/html.ts
@@ -28,7 +28,7 @@ export function escape_once (str: string) {
 }
 
 export function newline_to_br (v: string) {
-  return stringify(v).replace(/\n/g, '<br />\n')
+  return stringify(v).replace(/\r?\n/gm, '<br />\n')
 }
 
 export function strip_html (v: string) {

--- a/src/filters/string.ts
+++ b/src/filters/string.ts
@@ -74,7 +74,7 @@ export function strip (v: string, chars?: string) {
 }
 
 export function strip_newlines (v: string) {
-  return stringify(v).replace(/\n/g, '')
+  return stringify(v).replace(/\r?\n/gm, '')
 }
 
 export function capitalize (str: string) {

--- a/test/integration/filters/html.spec.ts
+++ b/test/integration/filters/html.spec.ts
@@ -30,7 +30,7 @@ describe('filters/html', function () {
     it('should support string_with_newlines', function () {
       const src = '{% capture string_with_newlines %}\n' +
               'Hello\n' +
-              'there\n' +
+              'there\r\n' +
               '{% endcapture %}' +
               '{{ string_with_newlines | newline_to_br }}'
       const dst = '<br />\n' +

--- a/test/integration/filters/string.spec.ts
+++ b/test/integration/filters/string.spec.ts
@@ -137,6 +137,12 @@ describe('filters/string', function () {
             '{{ string_with_newlines | strip_newlines }}',
     'Hellothere')
   })
+  it('should support strip_newlines on Windows newlines ', function () {
+    return test('{% capture string_with_newlines %}\n' +
+            'Hello\r\nthere\n{% endcapture %}' +
+            '{{ string_with_newlines | strip_newlines }}',
+    'Hellothere')
+  })
   describe('truncate', function () {
     it('should truncate when string too long', function () {
       return test('{{ "Ground control to Major Tom." | truncate: 20 }}',


### PR DESCRIPTION
Not sure if they are handled by javascript already, but might as well consider the case.