### PR TITLE
chore: adjust typings dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "./dist/liquid.node.cjs.js": "./dist/liquid.browser.umd.js",
     "./dist/liquid.node.esm.js": "./dist/liquid.browser.esm.js"
   },
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=14"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -18,11 +18,12 @@ const treeshake = {
 const tsconfig = (target) => ({
   check: true,
   tsconfigOverride: {
-    include: [ 'src' ],
-    exclude: [ 'test', 'benchmark' ],
+    include: ['src'],
+    exclude: ['test', 'benchmark'],
     compilerOptions: {
       target,
-      module: 'ES2015'
+      module: 'ES2015',
+      rootDir: 'src'
     }
   }
 })


### PR DESCRIPTION
Adjust the compatible typing file path to keep it consistent with historical versions.

Now
```ts
import { Tag } from 'liquidjs/dist/src/tags/assign'
```

Old
```ts
import { Tag } from 'liquidjs/dist/tags/assign'
```

