### PR TITLE
fix: Rely on equal for computing contains

### DIFF
--- a/src/render/expression.spec.ts
+++ b/src/render/expression.spec.ts
@@ -147,6 +147,20 @@ describe('Expression', function () {
       const ctx = new Context({ x: 'XXX', X: new TemplateDrop() })
       expect(await toPromise(create('x contains X').evaluate(ctx, false))).toBe(true)
     })
+    it('should support Drops for "x contains "x"" when x is an array', async () => {
+      class TemplateDrop extends Drop {
+        valueOf () { return 'X' }
+      }
+      const ctx = new Context({ x: [new TemplateDrop()], X: 'X' })
+      expect(await toPromise(create('x contains X').evaluate(ctx, false))).toBe(true)
+    })
+    it('should support Drops for "x contains "x"" when x is an array on both operands', async () => {
+      class TemplateDrop extends Drop {
+        valueOf () { return 'X' }
+      }
+      const ctx = new Context({ x: [new TemplateDrop()], X: new TemplateDrop() })
+      expect(await toPromise(create('x contains X').evaluate(ctx, false))).toBe(true)
+    })
     it('should support value and !=', async function () {
       const ctx = new Context({ empty: '' })
       expect(await toPromise(create('empty and empty != ""').evaluate(ctx, false))).toBe(false)

--- a/src/render/operator.ts
+++ b/src/render/operator.ts
@@ -34,8 +34,8 @@ export const defaultOperators: Operators = {
   },
   'contains': (l: any, r: any) => {
     l = toValue(l)
-    if (l && isArray(l)) return l.some((i) => equal(i, r))
-    if (l && isString(l)) return l.indexOf(toValue(r)) > -1
+    if (isArray(l)) return l.some((i) => equal(i, r))
+    if (isString(l)) return l.indexOf(toValue(r)) > -1
     return false
   },
   'not': (v: any, ctx: Context) => isFalsy(toValue(v), ctx),

--- a/src/render/operator.ts
+++ b/src/render/operator.ts
@@ -1,8 +1,8 @@
 import { isComparable } from '../drop/comparable'
 import { Context } from '../context'
-import { isFunction, toValue } from '../util'
+import { toValue } from '../util'
 import { isFalsy, isTruthy } from '../render/boolean'
-import { isArray } from '../util/underscore'
+import { isArray, isString } from '../util/underscore'
 
 export type UnaryOperatorHandler = (operand: any, ctx: Context) => boolean;
 export type BinaryOperatorHandler = (lhs: any, rhs: any, ctx: Context) => boolean;
@@ -34,8 +34,9 @@ export const defaultOperators: Operators = {
   },
   'contains': (l: any, r: any) => {
     l = toValue(l)
-    r = toValue(r)
-    return l && isFunction(l.indexOf) ? l.indexOf(r) > -1 : false
+    if (l && isArray(l)) return l.some((i) => equal(i, r))
+    if (l && isString(l)) return l.indexOf(toValue(r)) > -1
+    return false
   },
   'not': (v: any, ctx: Context) => isFalsy(toValue(v), ctx),
   'and': (l: any, r: any, ctx: Context) => isTruthy(toValue(l), ctx) && isTruthy(toValue(r), ctx),


### PR DESCRIPTION
This change allows the `contains` to be computed using the `toValue` of the items in the array.

Before this change if I had an array of "Drop" `contains` would not match against the value.

*this is not valid liquid, this is just to explain the case i'm trying to fix*
```
{{[Drop("hello"), Drop("bye")] | contains "hello"}} -> false
```
with the changes on this pr, it will return true.