### PR TITLE
fix: throw error on 'else if' tag

### DIFF
--- a/src/tokens/tag-token.ts
+++ b/src/tokens/tag-token.ts
@@ -19,6 +19,7 @@ export class TagToken extends DelimitedToken {
     this.tokenizer = new Tokenizer(input, options.operators, file, this.contentRange)
     this.name = this.tokenizer.readTagName()
     this.tokenizer.assert(this.name, `illegal tag syntax, tag name expected`)
+    this.tokenizer.assert(this.name !== 'else' || this.contentRange[1] - this.contentRange[0] === 4, () => `unexpected token: ${this.tokenizer.snapshot()}`)
     this.tokenizer.skipBlank()
   }
   get args (): string {

--- a/test/e2e/issues.spec.ts
+++ b/test/e2e/issues.spec.ts
@@ -469,4 +469,9 @@ describe('Issues', function () {
     const result = engine.parseAndRenderSync('{{ÜLKE}}', { ÜLKE: 'Türkiye' })
     expect(result).toEqual('Türkiye')
   })
+  it('#667 should throw if \'else if\' is used instead of \'elsif\'', () => {
+    const engine = new Liquid()
+    const tpl = '{% if true %}true{% else if false %}false{% endif %}'
+    expect(() => engine.parse(tpl)).toThrow('unexpected token: " if false"')
+  })
 })


### PR DESCRIPTION
Throw an error if there is an invalid `else` tag:  #667