### PR TITLE
fix: in conditionals, don't render anything after an else branch

### DIFF
--- a/docs/themes/navy/layout/partial/all-contributors.swig
+++ b/docs/themes/navy/layout/partial/all-contributors.swig
@@ -75,6 +75,8 @@
       <td align="center" valign="top" width="0%"><a href="http://ebobby.org"><img src="https://avatars.githubusercontent.com/u/170356?v=4?s=100" width="100px;" alt="Francisco Soto"/></a></td>
       <td align="center" valign="top" width="0%"><a href="https://www.davidlj95.com"><img src="https://avatars.githubusercontent.com/u/8050648?v=4?s=100" width="100px;" alt="David LJ"/></a></td>
       <td align="center" valign="top" width="0%"><a href="https://github.com/RasmusWL"><img src="https://avatars.githubusercontent.com/u/1054041?v=4?s=100" width="100px;" alt="Rasmus Wriedt Larsen"/></a></td>
+      <td align="center" valign="top" width="0%"><a href="https://github.com/brunodccarvalho"><img src="https://avatars.githubusercontent.com/u/24962950?v=4?s=100" width="100px;" alt="Bruno Carvalho"/></a></td>
+      <td align="center" valign="top" width="0%"><a href="https://github.com/fupengl"><img src="https://avatars.githubusercontent.com/u/20211964?v=4?s=100" width="100px;" alt="傅鹏"/></a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/themes/navy/layout/partial/all-contributors.swig
+++ b/docs/themes/navy/layout/partial/all-contributors.swig
@@ -75,8 +75,6 @@
       <td align="center" valign="top" width="0%"><a href="http://ebobby.org"><img src="https://avatars.githubusercontent.com/u/170356?v=4?s=100" width="100px;" alt="Francisco Soto"/></a></td>
       <td align="center" valign="top" width="0%"><a href="https://www.davidlj95.com"><img src="https://avatars.githubusercontent.com/u/8050648?v=4?s=100" width="100px;" alt="David LJ"/></a></td>
       <td align="center" valign="top" width="0%"><a href="https://github.com/RasmusWL"><img src="https://avatars.githubusercontent.com/u/1054041?v=4?s=100" width="100px;" alt="Rasmus Wriedt Larsen"/></a></td>
-      <td align="center" valign="top" width="0%"><a href="https://github.com/brunodccarvalho"><img src="https://avatars.githubusercontent.com/u/24962950?v=4?s=100" width="100px;" alt="Bruno Carvalho"/></a></td>
-      <td align="center" valign="top" width="0%"><a href="https://github.com/fupengl"><img src="https://avatars.githubusercontent.com/u/20211964?v=4?s=100" width="100px;" alt="傅鹏"/></a></td>
     </tr>
   </tbody>
 </table>

--- a/src/tags/case.ts
+++ b/src/tags/case.ts
@@ -35,7 +35,6 @@ export default class extends Tag {
         })
       })
       .on('tag:else', () => {
-        p = []
         elseCount++
         p = this.elseTemplates
       })

--- a/src/tags/case.ts
+++ b/src/tags/case.ts
@@ -10,8 +10,13 @@ export default class extends Tag {
     this.elseTemplates = []
 
     let p: Template[] = []
+    let elseCount = 0
     const stream: ParseStream = this.liquid.parser.parseStream(remainTokens)
       .on('tag:when', (token: TagToken) => {
+        if (elseCount > 0) {
+          return
+        }
+
         p = []
 
         const values: ValueToken[] = []
@@ -29,10 +34,14 @@ export default class extends Tag {
           templates: p
         })
       })
-      .on('tag:else', () => (p = this.elseTemplates))
+      .on('tag:else', () => {
+        p = []
+        elseCount++
+        p = this.elseTemplates
+      })
       .on('tag:endcase', () => stream.stop())
       .on('template', (tpl: Template) => {
-        if (p !== this.elseTemplates || (p === this.elseTemplates && p.length === 0)) {
+        if (p !== this.elseTemplates || (p === this.elseTemplates && elseCount === 1)) {
           p.push(tpl)
         }
       })

--- a/src/tags/case.ts
+++ b/src/tags/case.ts
@@ -31,7 +31,11 @@ export default class extends Tag {
       })
       .on('tag:else', () => (p = this.elseTemplates))
       .on('tag:endcase', () => stream.stop())
-      .on('template', (tpl: Template) => p.push(tpl))
+      .on('template', (tpl: Template) => {
+        if (p !== this.elseTemplates || (p === this.elseTemplates && p.length === 0)) {
+          p.push(tpl)
+        }
+      })
       .on('end', () => {
         throw new Error(`tag ${tagToken.getText()} not closed`)
       })

--- a/src/tags/case.ts
+++ b/src/tags/case.ts
@@ -40,7 +40,7 @@ export default class extends Tag {
       })
       .on('tag:endcase', () => stream.stop())
       .on('template', (tpl: Template) => {
-        if (p !== this.elseTemplates || (p === this.elseTemplates && elseCount === 1)) {
+        if (p !== this.elseTemplates || elseCount === 1) {
           p.push(tpl)
         }
       })

--- a/src/tags/if.ts
+++ b/src/tags/if.ts
@@ -29,7 +29,7 @@ export default class extends Tag {
       })
       .on('tag:endif', function () { this.stop() })
       .on('template', (tpl: Template) => {
-        if (p !== this.elseTemplates || (p === this.elseTemplates && elseCount === 1)) {
+        if (p !== this.elseTemplates || elseCount === 1) {
           p.push(tpl)
         }
       })

--- a/src/tags/if.ts
+++ b/src/tags/if.ts
@@ -13,10 +13,16 @@ export default class extends Tag {
         value: new Value(tagToken.args, this.liquid),
         templates: (p = [])
       }))
-      .on('tag:elsif', (token: TagToken) => this.branches.push({
-        value: new Value(token.args, this.liquid),
-        templates: (p = [])
-      }))
+      .on('tag:elsif', (token: TagToken) => {
+        if (elseCount > 0) {
+          p = []
+          return
+        }
+        this.branches.push({
+          value: new Value(token.args, this.liquid),
+          templates: (p = [])
+        })
+      })
       .on('tag:else', () => {
         elseCount++
         p = this.elseTemplates

--- a/src/tags/if.ts
+++ b/src/tags/if.ts
@@ -7,6 +7,7 @@ export default class extends Tag {
   constructor (tagToken: TagToken, remainTokens: TopLevelToken[], liquid: Liquid) {
     super(tagToken, remainTokens, liquid)
     let p: Template[] = []
+    let elseCount = 0
     liquid.parser.parseStream(remainTokens)
       .on('start', () => this.branches.push({
         value: new Value(tagToken.args, this.liquid),
@@ -16,10 +17,13 @@ export default class extends Tag {
         value: new Value(token.args, this.liquid),
         templates: (p = [])
       }))
-      .on('tag:else', () => (p = this.elseTemplates))
+      .on('tag:else', () => {
+        elseCount++
+        p = this.elseTemplates
+      })
       .on('tag:endif', function () { this.stop() })
       .on('template', (tpl: Template) => {
-        if (p !== this.elseTemplates || (p === this.elseTemplates && p.length === 0)) {
+        if (p !== this.elseTemplates || (p === this.elseTemplates && elseCount === 1)) {
           p.push(tpl)
         }
       })

--- a/src/tags/if.ts
+++ b/src/tags/if.ts
@@ -6,7 +6,7 @@ export default class extends Tag {
 
   constructor (tagToken: TagToken, remainTokens: TopLevelToken[], liquid: Liquid) {
     super(tagToken, remainTokens, liquid)
-    let p
+    let p: Template[] = []
     liquid.parser.parseStream(remainTokens)
       .on('start', () => this.branches.push({
         value: new Value(tagToken.args, this.liquid),
@@ -18,7 +18,11 @@ export default class extends Tag {
       }))
       .on('tag:else', () => (p = this.elseTemplates))
       .on('tag:endif', function () { this.stop() })
-      .on('template', (tpl: Template) => p.push(tpl))
+      .on('template', (tpl: Template) => {
+        if (p !== this.elseTemplates || (p === this.elseTemplates && p.length === 0)) {
+          p.push(tpl)
+        }
+      })
       .on('end', () => { throw new Error(`tag ${tagToken.getText()} not closed`) })
       .start()
   }

--- a/src/tags/unless.ts
+++ b/src/tags/unless.ts
@@ -5,7 +5,7 @@ export default class extends Tag {
   elseTemplates: Template[] = []
   constructor (tagToken: TagToken, remainTokens: TopLevelToken[], liquid: Liquid) {
     super(tagToken, remainTokens, liquid)
-    let p
+    let p: Template[] = []
     this.liquid.parser.parseStream(remainTokens)
       .on('start', () => this.branches.push({
         value: new Value(tagToken.args, this.liquid),
@@ -19,7 +19,11 @@ export default class extends Tag {
       }))
       .on('tag:else', () => (p = this.elseTemplates))
       .on('tag:endunless', function () { this.stop() })
-      .on('template', (tpl: Template) => p.push(tpl))
+      .on('template', (tpl: Template) => {
+        if (p !== this.elseTemplates || (p === this.elseTemplates && p.length === 0)) {
+          p.push(tpl)
+        }
+      })
       .on('end', () => { throw new Error(`tag ${tagToken.getText()} not closed`) })
       .start()
   }

--- a/src/tags/unless.ts
+++ b/src/tags/unless.ts
@@ -6,6 +6,7 @@ export default class extends Tag {
   constructor (tagToken: TagToken, remainTokens: TopLevelToken[], liquid: Liquid) {
     super(tagToken, remainTokens, liquid)
     let p: Template[] = []
+    let elseCount = 0
     this.liquid.parser.parseStream(remainTokens)
       .on('start', () => this.branches.push({
         value: new Value(tagToken.args, this.liquid),
@@ -17,10 +18,13 @@ export default class extends Tag {
         test: isTruthy,
         templates: (p = [])
       }))
-      .on('tag:else', () => (p = this.elseTemplates))
+      .on('tag:else', () => {
+        elseCount++
+        p = this.elseTemplates
+      })
       .on('tag:endunless', function () { this.stop() })
       .on('template', (tpl: Template) => {
-        if (p !== this.elseTemplates || (p === this.elseTemplates && p.length === 0)) {
+        if (p !== this.elseTemplates || (p === this.elseTemplates && elseCount === 1)) {
           p.push(tpl)
         }
       })

--- a/src/tags/unless.ts
+++ b/src/tags/unless.ts
@@ -13,11 +13,17 @@ export default class extends Tag {
         test: isFalsy,
         templates: (p = [])
       }))
-      .on('tag:elsif', (token: TagToken) => this.branches.push({
-        value: new Value(token.args, this.liquid),
-        test: isTruthy,
-        templates: (p = [])
-      }))
+      .on('tag:elsif', (token: TagToken) => {
+        if (elseCount > 0) {
+          p = []
+          return
+        }
+        this.branches.push({
+          value: new Value(token.args, this.liquid),
+          test: isTruthy,
+          templates: (p = [])
+        })
+      })
       .on('tag:else', () => {
         elseCount++
         p = this.elseTemplates

--- a/src/tags/unless.ts
+++ b/src/tags/unless.ts
@@ -30,7 +30,7 @@ export default class extends Tag {
       })
       .on('tag:endunless', function () { this.stop() })
       .on('template', (tpl: Template) => {
-        if (p !== this.elseTemplates || (p === this.elseTemplates && elseCount === 1)) {
+        if (p !== this.elseTemplates || elseCount === 1) {
           p.push(tpl)
         }
       })

--- a/test/e2e/issues.spec.ts
+++ b/test/e2e/issues.spec.ts
@@ -469,19 +469,12 @@ describe('Issues', function () {
     const result = engine.parseAndRenderSync('{{ÜLKE}}', { ÜLKE: 'Türkiye' })
     expect(result).toEqual('Türkiye')
   })
-  it('#670 Does not render multiple `else` branches in the same if conditional', () => {
+  it('#670 Should not render anything after an else branch', () => {
     const engine = new Liquid()
-    const result = engine.parseAndRenderSync(`{% if false %}don't show{% else %}show{% else %}don't show{% endif %}`, {})
-    expect(result).toEqual('show')
-  })
-  it('#670 Does not render multiple `else` branches in the same unless conditional', () => {
-    const engine = new Liquid()
-    const result = engine.parseAndRenderSync(`{% unless true %}don't show{% else %}show{% else %}don't show{% endunless %}`, {})
-    expect(result).toEqual('show')
-  })
-  it('#670 Does not render multiple `else` branches in the same case conditional', () => {
-    const engine = new Liquid()
-    const result = engine.parseAndRenderSync(`{% case true %}{% when false %}don't show{% else %}show{% else %}don't show{% endcase %}`, {})
-    expect(result).toEqual('show')
+    const result = engine.parseAndRenderSync('{% assign value = "this" %}' +
+      '{% if false %}don\'t show' +
+      '{% else %}show {{ value }}' +
+    '{% else %}don\'t show{% endif %}', {})
+    expect(result).toEqual('show this')
   })
 })

--- a/test/e2e/issues.spec.ts
+++ b/test/e2e/issues.spec.ts
@@ -469,4 +469,19 @@ describe('Issues', function () {
     const result = engine.parseAndRenderSync('{{ÜLKE}}', { ÜLKE: 'Türkiye' })
     expect(result).toEqual('Türkiye')
   })
+  it('#670 Does not render multiple `else` branches in the same if conditional', () => {
+    const engine = new Liquid()
+    const result = engine.parseAndRenderSync(`{% if false %}don't show{% else %}show{% else %}don't show{% endif %}`, {})
+    expect(result).toEqual('show')
+  })
+  it('#670 Does not render multiple `else` branches in the same unless conditional', () => {
+    const engine = new Liquid()
+    const result = engine.parseAndRenderSync(`{% unless true %}don't show{% else %}show{% else %}don't show{% endunless %}`, {})
+    expect(result).toEqual('show')
+  })
+  it('#670 Does not render multiple `else` branches in the same case conditional', () => {
+    const engine = new Liquid()
+    const result = engine.parseAndRenderSync(`{% case true %}{% when false %}don't show{% else %}show{% else %}don't show{% endcase %}`, {})
+    expect(result).toEqual('show')
+  })
 })

--- a/test/e2e/issues.spec.ts
+++ b/test/e2e/issues.spec.ts
@@ -477,4 +477,12 @@ describe('Issues', function () {
     '{% else %}don\'t show{% endif %}', {})
     expect(result).toEqual('show this')
   })
+  it('#672 Should not render an elseif after an else branch', () => {
+    const engine = new Liquid()
+    const result = engine.parseAndRenderSync('{% if false %}don\'t show' +
+      '{% else %}show' +
+      '{% elsif true %}don\'t show' +
+    '{% endif %}', {})
+    expect(result).toEqual('show')
+  })
 })

--- a/test/integration/tags/case.spec.ts
+++ b/test/integration/tags/case.spec.ts
@@ -91,4 +91,32 @@ describe('tags/case', function () {
     const html = await liquid.parseAndRender(src)
     return expect(html).toBe('and or or')
   })
+  it('should not render anything after an else branch', async function () {
+    const html = await liquid.parseAndRenderSync('{% assign value = "this" %}' +
+    '{% case true %}' +
+      '{% when false %}don\'t show' +
+      '{% else %}show {{ value }}' +
+      '{% else %}don\'t show' +
+    '{% endcase %}', {})
+    expect(html).toEqual('show this')
+  })
+  it('should not render anything after an else branch even when first else branch is empty', async function () {
+    const html = await liquid.parseAndRenderSync('{% case true %}' +
+      '{% when false %}don\'t show' +
+      '{% else %}' +
+      '{% else %}don\'t show' +
+    '{% endcase %}', {})
+    expect(html).toEqual('')
+  })
+  it('should not render anything after an else branch even when there are \'when\' conditions', () => {
+    const engine = new Liquid()
+    const result = engine.parseAndRenderSync('{% assign value = "this" %}' +
+    '{% case true -%}' +
+      '{% when false -%}don\'t show' +
+      '{% else %}show {{ value }}' +
+      '{% else %}don\'t show' +
+      '{%- when true -%}don\'t show' +
+    '{%- endcase %}', {})
+    expect(result).toEqual('show this')
+  })
 })

--- a/test/integration/tags/if.spec.ts
+++ b/test/integration/tags/if.spec.ts
@@ -143,4 +143,12 @@ describe('tags/if', function () {
     const html = await liquid.parseAndRender(src, scope)
     return expect(html).toBe('success')
   })
+  it('should not render anything after an else branch even when first else branch is empty', () => {
+    const engine = new Liquid()
+    const result = engine.parseAndRenderSync('{% if false %}don\'t show' +
+      '{% else %}' +
+      '{% else %}don\'t show' +
+    '%{% endif %}', {})
+    expect(result).toEqual('')
+  })
 })

--- a/test/integration/tags/unless.spec.ts
+++ b/test/integration/tags/unless.spec.ts
@@ -47,6 +47,21 @@ describe('tags/unless', function () {
       Inside wonderland
       After wonderland`)
   })
+  it('should not render anything after an else branch', async function () {
+    const html = await liquid.parseAndRenderSync('{% assign value = "this" %}' +
+      '{% unless true %}don\'t show' +
+      '{% else %}show {{ value }}' +
+      '{% else %}don\'t show' +
+    '{% endunless %}', {})
+    expect(html).toEqual('show this')
+  })
+  it('should not render anything after an else branch even when first else branch is empty', async function () {
+    const html = await liquid.parseAndRenderSync('{% unless true %}don\'t show' +
+      '{% else %}' +
+      '{% else %}don\'t show' +
+    '{% endunless %}', {})
+    expect(html).toEqual('')
+  })
 
   describe('sync support', function () {
     it('should render else when predicate yields true', function () {

--- a/test/integration/tags/unless.spec.ts
+++ b/test/integration/tags/unless.spec.ts
@@ -62,6 +62,14 @@ describe('tags/unless', function () {
     '{% endunless %}', {})
     expect(html).toEqual('')
   })
+  it('should not render an elseif after an else branch', () => {
+    const engine = new Liquid()
+    const result = engine.parseAndRenderSync('{% unless true %}don\'t show' +
+      '{% else %}show' +
+      '{% elsif true %}don\'t show' +
+    '{% endunless %}', {})
+    expect(result).toEqual('show')
+  })
 
   describe('sync support', function () {
     it('should render else when predicate yields true', function () {


### PR DESCRIPTION
This PR enforces a simple rule: don't render anything after an `else` branch.

There are several bugs currently where `if`, `unless` and `case` conditionals can have branches that occur after an `else` render, or that branches after an `else` can actually cause the `else` branch itself not to render.

Fixes: #670 and #672

## Example
```liquid
<p>If</p>
{% if false %}
  don't show
  {%- else -%}
  show
  {%- else -%}
  don't show
{% endif %}

<p>If with Elsif</p>
{% if false %}
  don't show
  {%- else -%}
  show
  {%- elsif true -%}
  don't show
{% endif %}

<p>Unless</p>
{% unless true %}
  don't show
  {%- else -%}
  show
  {%- else -%}
  don't show
{% endunless %}

<p>Case</p>
{% case true %}
  {%- when false- %}
    don't show
  {%- else -%}
    show
  {%- else -%}
    don't show
{% endcase %}

<p>Case with When</p>
{% case true -%}
  {% when false -%}
    don't show (false)
  {%- else -%}
    show
  {%- else -%}
    don't show (second else)
  {%- when true -%}
    don't show (truthy when condition after else)
  {%- when true -%}
    don't show (truthy when condition after else)
{%- endcase %}
```

**`master` Behaviour**:
```html
<p>If</p>
showdon't show

<p>If with Elsif</p>
don't show

<p>Unless</p>
showdon't show

<p>Case</p>
showdon't show

<p>Case with When</p>
don't show (truthy when condition after else)don't show (truthy when condition after else)
```

**PR Behaviour**:
```html
<p>If</p>
show

<p>If with Elsif</p>
show

<p>Unless</p>
show

<p>Case</p>
show
 
<p>Case with When</p>
show
```