### PR TITLE
fix: Allow `lenientIf` for multiple operands (issue #682)

### DIFF
--- a/src/render/expression.ts
+++ b/src/render/expression.ts
@@ -24,7 +24,7 @@ export class Expression {
         }
         operands.push(result)
       } else {
-        operands.push(yield evalToken(token, ctx, lenient && this.postfix.length === 1))
+        operands.push(yield evalToken(token, ctx, lenient))
       }
     }
     return operands[0]

--- a/test/integration/liquid/strict.spec.ts
+++ b/test/integration/liquid/strict.spec.ts
@@ -55,10 +55,15 @@ describe('LiquidOptions#strict*', function () {
       const html = await engine.render(tpl, ctx)
       return expect(html).toBe('beforeXafter')
     })
-    it('should still throw with an undefined variable in a compound `if` expression', function () {
-      const tpl = engine.parse('{% if notdefined == 15 %}a{% endif %}')
-      const fhtml = engine.render(tpl, ctx)
-      return expect(fhtml).rejects.toThrow(/undefined variable: notdefined/)
+    it('should not throw with an undefined variable in a compound `if` expression', async function () {
+      const tpl = engine.parse('before{% if notdefined == 15 %}X{% else %}Y{% endif %}after')
+      const html = await engine.render(tpl, ctx)
+      return expect(html).toBe('beforeYafter')
+    })
+    it('should correctly evaluate undefined variable in a compound `if` expression', async function () {
+      const tpl = engine.parse('before{% if notdefined != "value" %}X{% else %}Y{% endif %}after')
+      const html = await engine.render(tpl, ctx)
+      return expect(html).toBe('beforeXafter')
     })
     it('should allow an undefined variable when before the `default` filter', async function () {
       const tpl = engine.parse('{{notdefined | default: "a" | tolower}}')


### PR DESCRIPTION
Closes https://github.com/harttle/liquidjs/issues/682