### PR TITLE
fix: allow liquidMethodMissing to return any supported value type

### DIFF
--- a/src/drop/drop.ts
+++ b/src/drop/drop.ts
@@ -1,5 +1,5 @@
 export abstract class Drop {
-  public liquidMethodMissing (key: string | number): Promise<string | undefined> | string | undefined {
+  public liquidMethodMissing (key: string | number): Promise<any | undefined> | any | undefined {
     return undefined
   }
 }

--- a/src/drop/drop.ts
+++ b/src/drop/drop.ts
@@ -1,5 +1,5 @@
 export abstract class Drop {
-  public liquidMethodMissing (key: string | number): Promise<any | undefined> | any | undefined {
+  public liquidMethodMissing (key: string | number): Promise<any> | any {
     return undefined
   }
 }

--- a/test/integration/drop/drop.spec.ts
+++ b/test/integration/drop/drop.spec.ts
@@ -83,4 +83,20 @@ describe('drop/drop', function () {
     const html = await liquid.parseAndRender(tpl, { address, customer })
     expect(html).toBe('test')
   })
+  it('should support returning supported value types from liquidMethodMissing', async function () {
+    class DynamicTypeDrop extends Drop {
+      liquidMethodMissing (key: string) {
+        switch (key) {
+          case 'number': return 42
+          case 'string': return 'foo'
+          case 'boolean': return true
+          case 'array': return [1, 2, 3]
+          case 'object': return { foo: 'bar' }
+          case 'drop': return new CustomDrop()
+        }
+      }
+    }
+    const html = await liquid.parseAndRender(`{{obj.number}} {{obj.string}} {{obj.boolean}} {{obj.array | first}} {{obj.object.foo}} {{obj.drop.getName}}`, { obj: new DynamicTypeDrop() })
+    expect(html).toBe('42 foo true 1 bar GET NAME')
+  })
 })


### PR DESCRIPTION
The issue is that the type of `liquidMethodMissing` is too restrictive and only allows returning `string` rather than any supported value type. I ran into this issue when trying to return a `Drop` from `liquidMethodMissing` to enable dynamic lookups along an entire accessor chain.