### PR TITLE
feat: support catching all errors, #220

### DIFF
--- a/src/liquid-options.ts
+++ b/src/liquid-options.ts
@@ -32,6 +32,8 @@ export interface LiquidOptions {
   strictFilters?: boolean;
   /** Whether or not to assert variable existence.  If set to `false`, undefined variables will be rendered as empty string.  Otherwise, undefined variables will cause an exception. Defaults to `false`. */
   strictVariables?: boolean;
+  /** Catch all errors instead of exit upon one. Please note that render errors won't be reached when parse fails. */
+  catchAllErrors?: boolean;
   /** Hide scope variables from prototypes, useful when you're passing a not sanitized object into LiquidJS or need to hide prototypes from templates. */
   ownPropertyOnly?: boolean;
   /** Modifies the behavior of `strictVariables`. If set, a single undefined variable will *not* cause an exception in the context of the `if`/`elsif`/`unless` tag and the `default` filter. Instead, it will evaluate to `false` and `null`, respectively. Irrelevant if `strictVariables` is not set. Defaults to `false`. **/

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -8,7 +8,7 @@ import { Template } from '../template/template'
 const TRAIT = '__liquidClass__'
 
 export abstract class LiquidError extends Error {
-  private token!: Token
+  public token!: Token
   public context = ''
   private originalError?: Error
   public constructor (err: Error | string, token: Token) {
@@ -59,6 +59,19 @@ export class RenderError extends LiquidError {
   }
   public static is (obj: any): obj is RenderError {
     return obj.name === 'RenderError'
+  }
+}
+
+export class LiquidErrors extends LiquidError {
+  public constructor (public errors: RenderError[]) {
+    super(errors[0], errors[0].token)
+    this.name = 'LiquidErrors'
+    const s = errors.length > 1 ? 's' : ''
+    this.message = `${errors.length} error${s} found`
+    super.update()
+  }
+  public static is (obj: any): obj is LiquidErrors {
+    return obj.name === 'LiquidErrors'
   }
 }
 

--- a/test/stub/util.ts
+++ b/test/stub/util.ts
@@ -1,0 +1,6 @@
+export function throwIntendedError () {
+  throw new Error('intended error')
+}
+export async function rejectIntendedError () {
+  throw new Error('intended reject')
+}


### PR DESCRIPTION
Catching multiple errors before quit when `catchAllErrors` option is set. However there's some caveats.

1. It only catches all `LiquidError`, other errors like code bug are not catched in this way. So you'll need to check `err.name === 'LiquidErrors'` before using.
2. Top level tokennization errors are not catched, as there's no such concept of `Token` during this step. e.g. partial tag `{% foo`
3. Render errors should be catched perfectly. e.g. undefined variables, nonexist filters/tags, as well as errors thrown in filters/tags.