### PR TITLE
docs: Replace trimValue with trimOutput

### DIFF
--- a/docs/source/tutorials/whitespace-control.md
+++ b/docs/source/tutorials/whitespace-control.md
@@ -41,8 +41,8 @@ Alternatively, LiquidJS provides these per engine options to enable whitespace c
 
 * `trimTagLeft`
 * `trimTagRight`
-* `trimValueLeft`
-* `trimValueRight`
+* `trimOutputLeft`
+* `trimOutputRight`
 
 [LiquidJS][liquidjs] will **NOT** trim any whitespace by default, aka. above options all default to `false`. For details of these options, see the [options][options].
 


### PR DESCRIPTION
I believe this is a typo, as the config has been called `trimOutputLeft`/`Right` for 5 years: https://github.com/harttle/liquidjs/blame/83922032b79fd678237de8786f0d75fb33e6312f/src/liquid-options.ts#L54

I'm new to this library, so I could also be missing out on something, in which case feel free to close, but the `trimValue` options do not exist on Config.