### PR TITLE
fix: allow drops in property access

### DIFF
--- a/src/render/expression.spec.ts
+++ b/src/render/expression.spec.ts
@@ -50,6 +50,16 @@ describe('Expression', function () {
       expect(await toPromise(create('foo[doo["foo"]]').evaluate(ctx, false))).toBe('BAR')
       expect(await toPromise(create('doo[coo].foo').evaluate(ctx, false))).toBe('bar')
     })
+    it('should support drops in property access', async function () {
+      class TemplateDrop extends Drop {
+        valueOf () { return 'bar' }
+      }
+      const ctx = new Context({
+        foo: { bar: 'BAR' },
+        coo: new TemplateDrop()
+      })
+      expect(await toPromise(create('foo[coo]').evaluate(ctx, false))).toBe('BAR')
+    })
   })
 
   describe('simple expression', function () {

--- a/src/render/expression.ts
+++ b/src/render/expression.ts
@@ -2,6 +2,7 @@ import { QuotedToken, RangeToken, OperatorToken, Token, PropertyAccessToken, Ope
 import { isRangeToken, isPropertyAccessToken, UndefinedVariableError, range, isOperatorToken, assert } from '../util'
 import type { Context } from '../context'
 import type { UnaryOperatorHandler } from '../render'
+import { Drop } from '../drop'
 
 export class Expression {
   private postfix: Token[]
@@ -42,9 +43,9 @@ export function * evalToken (token: Token | undefined, ctx: Context, lenient = f
 }
 
 function * evalPropertyAccessToken (token: PropertyAccessToken, ctx: Context, lenient: boolean): IterableIterator<unknown> {
-  const props: string[] = []
+  const props: (string | number | Drop)[] = []
   for (const prop of token.props) {
-    props.push((yield evalToken(prop, ctx, false)) as unknown as string)
+    props.push((yield evalToken(prop, ctx, false)) as unknown as string | number | Drop)
   }
   try {
     if (token.variable) {


### PR DESCRIPTION
I noticed I wasn't able to use a Drop as a property access. This PR allows using Drops as key.