### PR TITLE
docs: Fix formatting bug in echo.md

### DIFF
--- a/docs/source/tags/echo.md
+++ b/docs/source/tags/echo.md
@@ -4,7 +4,7 @@ title: Echo
 
 {% since %}v9.31.0{% endsince %}
 
-Outputs an expression in the rendered HTML. This is identical to wrapping an expression in `{{` and `}}`, but works inside liquid tags and supports filters.
+Outputs an expression in the rendered HTML. This is identical to wrapping an expression in <code>{{</code> and <code>}}</code>, but works inside liquid tags and supports filters.
 
 ## echo
 


### PR DESCRIPTION
DISCLAIMER: This may not be the proper way to approach the issue.

Although the Markdown code is proper, on the website itself it is incorrectly rendered as <code>{{\` and `}}</code> (see screenshot below).

The reason for the disclaimer above is that I’m imagining this may be an issue at the content rendering level, and my fix here is just a workaround of that issue. — Given this, I’ll not be offended if this PR of mine is rejected and closed. 🙂

<table><tr><td>
<img width="700" alt="Screenshot 2025-05-10 at 08 35 51" src="https://github.com/user-attachments/assets/122e60ab-b7f6-476f-9e48-94acda3cf2a6" />
</table>