### PR TITLE
fix: block.super with strictVariables, #806

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For more details, refer to the [Setup Guide][setup].
 ## Who's Using LiquidJS?
 
 - [Eleventy](https://www.11ty.dev/): Eleventy, a simpler static site generator.
+- [Github Docs](https://github.com/github/docs): The open-source repo for docs.github.com.
 - [Opensense](https://www.opensense.com/): The smarter way to send email.
 - [Directus](https://docs.directus.io/): an instant REST+GraphQL API and intuitive no-code data collaboration app for any SQL database.
 - [Semgrep](https://github.com/returntocorp/semgrep): Lightweight static analysis for many languages.

--- a/src/drop/block-drop.ts
+++ b/src/drop/block-drop.ts
@@ -1,9 +1,10 @@
+import { Emitter, SimpleEmitter } from '../emitters'
 import { Drop } from './drop'
 
 export class BlockDrop extends Drop {
   constructor (
     // the block render from layout template
-    private superBlockRender: () => Iterable<any> = () => ''
+    private superBlockRender: (emitter: Emitter) => IterableIterator<unknown> | string = () => ''
   ) {
     super()
   }
@@ -11,7 +12,9 @@ export class BlockDrop extends Drop {
    * Provide parent access in child block by
    * {{ block.super }}
    */
-  public super () {
-    return this.superBlockRender()
+  public * super (): IterableIterator<unknown> {
+    const emitter = new SimpleEmitter()
+    yield this.superBlockRender(emitter)
+    return emitter.buffer
   }
 }

--- a/src/tags/block.ts
+++ b/src/tags/block.ts
@@ -39,7 +39,11 @@ export default class extends Tag {
       ctx.pop()
     }
     return renderChild
-      ? (superBlock: BlockDrop, emitter: Emitter) => renderChild(new BlockDrop(() => renderCurrent(superBlock, emitter)), emitter)
+      ? (superBlock: BlockDrop, emitter: Emitter) => renderChild(
+        new BlockDrop(
+          (emitter: Emitter) => renderCurrent(superBlock, emitter)
+        ),
+        emitter)
       : renderCurrent
   }
 

--- a/test/integration/tags/layout.spec.ts
+++ b/test/integration/tags/layout.spec.ts
@@ -101,6 +101,26 @@ describe('tags/layout', function () {
     const output = '<link href="base.css" rel="stylesheet"><link href="extra.css" rel="stylesheet">'
     return expect(html).toBe(output)
   })
+  it('should pass block.super as a string', async function () {
+    mock({
+      '/parent.html': '{% block css %}<link href="base.css" rel="stylesheet">{% endblock %}'
+    })
+    const src = '{% layout "parent.html" %}' +
+      '{%block css%}{{block.super}}<meta basesize={{block.super | size}}>{%endblock%}'
+    const html = await liquid.parseAndRender(src)
+    const output = '<link href="base.css" rel="stylesheet"><meta basesize=39>'
+    return expect(html).toBe(output)
+  })
+  it('should support block.super while strictVariables', async function () {
+    mock({
+      '/parent.html': '{% block css %}<link href="base.css" rel="stylesheet">{% endblock %}'
+    })
+    const src = '{% layout "parent.html" %}' +
+      '{%block css%}{{block.super}}<link href="extra.css" rel="stylesheet">{%endblock%}'
+    const html = await liquid.parseAndRender(src, undefined, { strictVariables: true })
+    const output = '<link href="base.css" rel="stylesheet"><link href="extra.css" rel="stylesheet">'
+    return expect(html).toBe(output)
+  })
   it('should render block.super to empty if no parent exists', async function () {
     mock({
       '/parent.html': '{% block css %}{{block.super}}<link href="base.css" rel="stylesheet">{% endblock %}'


### PR DESCRIPTION
`block.super` used to return a generator which emit contents into passed in `emmiter` and returns `undefined`, triggering `strictVariables` check. Credits to @kamikadzem22 for the investigation.

Furthermore, `block.super` seems to be a string but it isn't, in this PR also changes it to an actual string so it's more intuitive especially when users try to transform it.