### PR TITLE
docs: update tutorial on operators and precedence

### DIFF
--- a/docs/source/tutorials/operators.md
+++ b/docs/source/tutorials/operators.md
@@ -5,17 +5,18 @@ title: Operators
 LiquidJS operators are very simple and different. There're 2 types of operators supported:
 
 * Comparison operators: `==`, `!=`, `>`, `<`, `>=`, `<=`
-* Logic operators: `or`, `and`, `contains`
+* Logic operators: `not`, `or`, `and`, `contains`
 
 Thus numerical operators are not supported and you cannot even plus two numbers like this `{% raw %}{{a + b}}{% endraw %}`, instead we need a filter `{% raw %}{{ a | plus: b}}{% endraw %}`. Actually `+` is a valid variable name in LiquidJS.
 
 ## Precedence
 
-1. Comparison operators. All comparison operations have the same precedence and higher than logic operators.
-2. Logic operators. All logic operators have the same precedence.
+1. Comparison operators, and `contains`. All comparison operators alongside `contains` have the same (highest) precedence.
+2. `not` operator. It has slightly more precedence than `or` and `and`.
+3. `or` and `and` operators. These logic operators have the same (lowest) precedence.
 
 ## Associativity
 
 Logic operators are evaluated from right to left, see [shopify docs][operator-order].
 
-[operator-order]: https://help.shopify.com/en/themes/liquid/basics/operators#order-of-operations
+[operator-order]: https://shopify.dev/docs/api/liquid/basics#order-of-operations


### PR DESCRIPTION
This is a rather straightforward doc update:
- noticed that `not` operator was not listed on that page, added that
- fixed precedence descriptions, [looks like they got a bit out of date, too](https://github.com/harttle/liquidjs/blob/906707833e196733e592ca52fbe5eda48b71a8a6/src/tokens/operator-token.ts#L9-L20)
- updated the link to the corresponding section of shopify docs, the old one didn't work for me