### PR TITLE
fix: Support having new line and other whitespace after include filename

### DIFF
--- a/src/parser/tokenizer.ts
+++ b/src/parser/tokenizer.ts
@@ -422,7 +422,7 @@ export class Tokenizer {
 
   * readFileNameTemplate (options: NormalizedFullOptions): IterableIterator<TopLevelToken> {
     const { outputDelimiterLeft } = options
-    const htmlStopStrings = [',', ' ', outputDelimiterLeft]
+    const htmlStopStrings = [',', ' ', '\r', '\n', '\t', outputDelimiterLeft]
     const htmlStopStringSet = new Set(htmlStopStrings)
     // break on ',' and ' ', outputDelimiterLeft only stops HTML token
     while (this.p < this.N && !htmlStopStringSet.has(this.peek())) {

--- a/test/integration/tags/include.spec.ts
+++ b/test/integration/tags/include.spec.ts
@@ -265,6 +265,14 @@ describe('tags/include', function () {
       const html = liquid.renderFileSync('/current.html')
       return expect(html).toBe('FOO-')
     })
+    it('should support Jekyll style include with other whitespace before filename', function () {
+      mock({
+        '/current.html': '{% include bar/foo.html\r\n\ntitle="TITLE"\tcontent="FOO" %}',
+        '/bar/foo.html': '{{include.title}}={{include.content}}-{{content}}'
+      })
+      const html = liquid.renderFileSync('/current.html')
+      return expect(html).toBe('TITLE=FOO-')
+    })
     it('should support multiple parameters', function () {
       mock({
         '/current.html': '{% include bar/foo.html header="HEADER" content="CONTENT" %}',


### PR DESCRIPTION
Ruby's Liquid support having whitespace other than ' ' after filename (like new line)