### PR TITLE
Fix Path Traversal fallback vulnerability

### DIFF
--- a/src/fs/loader.ts
+++ b/src/fs/loader.ts
@@ -60,11 +60,11 @@ export class Loader {
       }
     }
   
-  if (fs.fallback === undefined) return                                                                                                                                                                                                                                      
-  const filepath = fs.fallback(file)                                                                                                                                                                                                                                         
-  if (filepath === undefined) return                                                                                                                                                                                                                                         
-  if (enforceRoot && !dirs.some(dir => this.contains(dir, filepath))) return
-  yield filepath
+    if (fs.fallback === undefined) return                                                                                                                                                                                                                                      
+    const filepath = fs.fallback(file)                                                                                                                                                                                                                                         
+    if (filepath === undefined) return                                                                                                                                                                                                                                         
+    if (enforceRoot && !dirs.some(dir => this.contains(dir, filepath))) return
+    yield filepath
 
   private dirname (path: string) {
     const fs = this.options.fs


### PR DESCRIPTION
**Vulnerability Summary**
The library fails to validate the resulting path of the fallback mechanism against the configured root directories. While the primary file lookup paths are protected by the contains() check, the fallback path yields the file path directly without verifying if it stays within the restricted boundaries.

**Proof of Concept (PoC)**
```
const { Liquid } = require('liquidjs');
const e = new Liquid({ root: ['/tmp'], partials: ['/tmp'], dynamicPartials: true });
e.parseAndRender('{% include page %}', { page: '../../../etc/passwd' }).then(o => console.log(o.slice(0,500)));
```

<img width="829" height="349" alt="image" src="https://github.com/user-attachments/assets/9a64a442-17e0-406a-b0a1-44d46bbc80b5" />


**Technical Analysis**
The issue resides in src/fs/loader.ts within the candidates() generator. Lines 49 and 58 correctly apply the enforceRoot and this.contains(dir, filepath) checks. However, the fallback block (Lines 62-65) lacks this security gate.

**Vulnerable Code (loader.ts):**


```
if (fs.fallback !== undefined) {
  const filepath = fs.fallback(file)
  if (filepath !== undefined) yield filepath
}
```

**Suggested Fix**
The fallback result should only be yielded if it satisfies the same security contract as the other candidate paths. I suggest the following modification:


```
if (fs.fallback !== undefined) {
  const filepath = fs.fallback(file)
  if (filepath !== undefined) {
    if (!enforceRoot || dirs.some(dir => this.contains(dir, filepath))) {
      yield filepath
    }
  }
}
```

This ensures that the fallback path is only allowed if it falls within one of the configured root directories, matching the intended security behavior of the library.

**Impact**
This is a high-severity issue for any application that passes user-controlled input to tags like {% include %} or {% render %} while relying on the root setting for isolation.