### PR TITLE
feat: add newline filter

### DIFF
--- a/docs/source/filters/newline.md
+++ b/docs/source/filters/newline.md
@@ -1,0 +1,17 @@
+# newline
+
+Appends a newline (`\n`) to the input string if it does not already end with one.
+
+This is useful for scenarios where multi-line string inputs are prevented and we rely on a single line definition for the liquid template.
+
+## Example
+
+```liquid
+{{ "Hello" | newline }}World
+```
+
+Output:
+
+```
+Hello\nWorld
+```

--- a/src/filters/string.ts
+++ b/src/filters/string.ts
@@ -199,3 +199,18 @@ export function array_to_sentence_string (this: FilterImpl, array: unknown[], co
       return `${array.slice(0, -1).join(', ')}, ${connector} ${array[array.length - 1]}`
   }
 }
+
+export function newline (this: FilterImpl, v: unknown) {
+  let str = stringify(v)
+
+  // Normalize windows newline
+  if (str.endsWith('\r\n')) {
+    str = str.slice(0, -2) + '\n'
+  }
+
+  this.context.memoryLimit.use(str.length + 1)
+
+  // Handle the case where newline is already added
+  if (str.endsWith('\n')) return str
+  return str + '\n'
+}

--- a/test/integration/filters/string.spec.ts
+++ b/test/integration/filters/string.spec.ts
@@ -347,4 +347,18 @@ describe('filters/string', function () {
       expect(html).toEqual('foo, bar, and baz')
     })
   })
+  describe('newline', function () {
+    it('should add newline character', async () => {
+      const result = await liquid.parseAndRender('{{"Hello" | newline}}World')
+      expect(result).toEqual('Hello\nWorld')
+    })
+    it('should ignore existing newline characters', async () => {
+      const result = await liquid.parseAndRender('{{"Hello\n" | newline}}World')
+      expect(result).toEqual('Hello\nWorld')
+    })
+    it('should ignore windows newline characters', async () => {
+      const result = await liquid.parseAndRender('{{"Hello\r\n" | newline}}World')
+      expect(result).toEqual('Hello\nWorld')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Adds a `newline` filter that appends a newline (`\n`) if the string does not already end with one.

This is useful for scenarios where we are limited to single line string inputs and provides explicit, normalised newline behaviour that is consistent across platforms.

## Example
{{ "Hello" | newline }}World

Output:
Hello
World

## Tests
Added integration tests for:
- normal case
- existing newline
- windows newline