### PR TITLE
fix: handle undefined replacement argument in replace filter

### DIFF
--- a/src/filters/string.ts
+++ b/src/filters/string.ts
@@ -137,6 +137,7 @@ export function capitalize (this: FilterImpl, str: string) {
 export function replace (this: FilterImpl, v: string, pattern: string, replacement: string) {
   const str = stringify(v)
   pattern = stringify(pattern)
+  replacement = stringify(replacement)
   this.context.memoryLimit.use(str.length + pattern.length + replacement.length)
   return str.split(pattern).join(replacement)
 }

--- a/test/integration/filters/string.spec.ts
+++ b/test/integration/filters/string.spec.ts
@@ -109,6 +109,14 @@ describe('filters/string', function () {
     return test('{{ "Take my protein pills and put my helmet on" | replace: "my", "your" }}',
       'Take your protein pills and put your helmet on')
   })
+  it('should support replace with undefined replacement', function () {
+    return test('{{ "Take my protein pills and put my helmet on" | replace: "my" }}',
+      'Take  protein pills and put  helmet on')
+  })
+  it('should support replace with undefined variable as replacement', function () {
+    return test('{{ "Take my protein pills and put my helmet on" | replace: "my", missing_variable }}',
+      'Take  protein pills and put  helmet on')
+  })
   it('should support replace_first', function () {
     return test('{% assign my_string = "Take my protein pills and put my helmet on" %}\n' +
             '{{ my_string | replace_first: "my", "your" }}',


### PR DESCRIPTION
## Summary
- The `replace` filter throws a TypeError when the replacement argument is undefined (either omitted or referencing a non-existent variable), because it calls `.length` on `undefined` before `stringify()`
- Added `replacement = stringify(replacement)` to match the existing pattern in `replace_first` and `replace_last`, which already handle this correctly
- Verified this matches Ruby Liquid behavior, where an omitted replacement removes the matched string

## Test plan
- Added test for `{{ "..." | replace: "my" }}` (omitted replacement)
- Added test for `{{ "..." | replace: "my", missing_variable }}` (undefined variable)