### PR TITLE
docs(readme): add Freshet to Who's Using LiquidJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For more details, refer to the [Setup Guide][setup].
 - [Microsoft Power Pages](https://learn.microsoft.com/en-us/power-pages/introduction): a secure, enterprise-grade, low-code software as a service (SaaS) platform for creating, hosting, and administering modern external-facing business websites.
 - [Azure API Management developer portal](https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-developer-portal): an automatically generated, fully customizable website with the documentation of your APIs.
 - [WISMOlabs](https://wismolabs.com/): Post Purchase Experience platform for eCommerce retailers enhancing customer satisfaction by using LiquidJS to provide customizable post-purchase experiences through programmable email, SMS, order tracking pages, and webhooks.
+- [Freshet](https://chromewebstore.google.com/detail/freshet/mpclplhdencffbilobpcapccnihpelcg): *JSON in, page out* — a Chrome extension that uses LiquidJS templates per URL pattern, so the JSON becomes a rendered, useful page.
 
 Feel free to create a PR or contact me to add your use case into this list!
 


### PR DESCRIPTION
This PR adds **Freshet** to the *Who's Using LiquidJS?* list.

Freshet is a Chrome extension that renders any JSON URL as a useful page using LiquidJS templates authored per URL pattern. LiquidJS was chosen because MV3's content-script CSP forbids `'unsafe-eval'`, which rules out compile-to-function template engines — LiquidJS's runtime interpreter works perfectly within the CSP.

- Chrome Web Store: https://chromewebstore.google.com/detail/freshet/mpclplhdencffbilobpcapccnihpelcg
- Live demos: https://mattaltermatt.github.io/freshet/try/
- Source: https://github.com/MattAltermatt/freshet
