### PR TITLE
fix: enforce renderLimit for empty renderTemplates calls

### DIFF
--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -15,6 +15,7 @@ export class Render {
     if (!emitter) {
       emitter = ctx.opts.keepOutputType ? new KeepingTypeEmitter() : new SimpleEmitter()
     }
+    ctx.renderLimit.check(getPerformance().now())
     const errors = []
     for (const tpl of templates) {
       ctx.renderLimit.check(getPerformance().now())

--- a/test/integration/liquid/dos.spec.ts
+++ b/test/integration/liquid/dos.spec.ts
@@ -48,6 +48,16 @@ describe('DoS related', function () {
       await expect(liquid.parseAndRender('{% render "large" %}')).rejects.toThrow('template render limit exceeded')
       await expect(liquid.parseAndRender('{% render "small" %}')).resolves.toBe('12345')
     })
+    it('should enforce renderLimit when for body has no template nodes', () => {
+      const liquid = new Liquid({ memoryLimit: 1e9, renderLimit: 1 })
+      expect(() => liquid.parseAndRenderSync('{%- for i in (1..5000000) -%}{%- endfor -%}', {}))
+        .toThrow('template render limit exceeded')
+    })
+    it('should enforce renderLimit when tablerow body has no template nodes', () => {
+      const liquid = new Liquid({ memoryLimit: 1e9, renderLimit: 1 })
+      expect(() => liquid.parseAndRenderSync('{%- tablerow i in (1..1000000) cols:1 -%}{%- endtablerow -%}', {}))
+        .toThrow('template render limit exceeded')
+    })
   })
   describe('#memoryLimit', () => {
     it('should throw for too many array creation in filters', async () => {


### PR DESCRIPTION
renderLimit was only checked inside the per-template loop, so renderTemplates([], ...) skipped it entirely. Empty {% for %} / {% tablerow %} bodies invoke that path once per iteration, bypassing the documented time budget. Check the limiter at renderTemplates entry before the loop.

Add regression test for empty for-body with a strict renderLimit.