### PR TITLE
fix: constrain in-memory template lookups

### DIFF
--- a/docs/source/tutorials/render-file.md
+++ b/docs/source/tutorials/render-file.md
@@ -109,7 +109,7 @@ engine.renderFileSync('views/entry'))
 // Result: 'header footer'
 ```
 
-Note that file system options like `root`, `layouts`, `partials`, `relativeReference` will be ignored when `templates` is specified.
+Note that the `fs` option will be ignored when `templates` is specified. `root`, `layouts`, `partials`, and `relativeReference` still control template lookup within the in-memory mapping.
 
 [fs]: /api/interfaces/LiquidOptions.html#fs
 [ifs]: /api/interfaces/FS.html

--- a/src/fs/map-fs.spec.ts
+++ b/src/fs/map-fs.spec.ts
@@ -30,6 +30,26 @@ describe('MapFS', () => {
     it('should resolve invalid path', () => {
       expect(fs.resolve('foo/bar', '..//coo', '')).toEqual('foo/coo')
     })
+    it('should resolve from a trailing separator', () => {
+      expect(fs.resolve('/foo/bar/', 'coo', '')).toEqual('/foo/bar/coo')
+    })
+  })
+  describe('#containsSync()', () => {
+    it('should contain files under root', () => {
+      expect(fs.containsSync('foo/bar', 'foo/bar/coo')).toBe(true)
+    })
+    it('should contain root itself', () => {
+      expect(fs.containsSync('foo/bar', 'foo/bar')).toBe(true)
+    })
+    it('should contain root itself with a trailing separator', () => {
+      expect(fs.containsSync('foo/bar/', 'foo/bar')).toBe(true)
+    })
+    it('should treat root as a terminated path', () => {
+      expect(fs.containsSync('foo/bar', 'foo/bar-baz/coo')).toBe(false)
+    })
+    it('should allow all files from default root', () => {
+      expect(fs.containsSync('.', 'foo/bar')).toBe(true)
+    })
   })
   describe('#.readFileSync()', () => {
     it('should throw if not exist', () => {

--- a/src/fs/map-fs.ts
+++ b/src/fs/map-fs.ts
@@ -23,6 +23,17 @@ export class MapFS {
     return content
   }
 
+  async contains (root: string, filepath: string) {
+    return this.containsSync(root, filepath)
+  }
+
+  containsSync (root: string, filepath: string) {
+    if (root === '.' || root === '') return true
+    const normalizedRoot = root.endsWith(this.sep) && root !== this.sep ? root.slice(0, -1) : root
+    const prefix = normalizedRoot.endsWith(this.sep) ? normalizedRoot : normalizedRoot + this.sep
+    return filepath === normalizedRoot || filepath.startsWith(prefix)
+  }
+
   dirname (filepath: string) {
     const segments = filepath.split(this.sep)
     segments.pop()
@@ -33,6 +44,7 @@ export class MapFS {
     file += ext
     if (dir === '.') return file
     const segments = dir.split(/\/+/)
+    if (segments.length > 1 && segments[segments.length - 1] === '') segments.pop()
     for (const segment of file.split(this.sep)) {
       if (segment === '.' || segment === '') continue
       else if (segment === '..') {

--- a/src/liquid-options.ts
+++ b/src/liquid-options.ts
@@ -72,7 +72,7 @@ export interface LiquidOptions {
   fs?: FS;
   /** keyValue separator */
   keyValueSeparator?: string;
-  /** Render from an in-memory `templates` mapping instead of the file system. When `templates` is set, Liquid uses the provided mapping for template lookup (including includes, layouts, and partials), and file-system options such as `fs`, `root`, `partials`, `layouts`, and `relativeReference` are effectively bypassed for those lookups. */
+  /** Render from an in-memory `templates` mapping instead of the file system. When `templates` is set, Liquid uses the provided mapping for template lookup (including includes, layouts, and partials). The `fs` option is ignored; `root`, `partials`, `layouts`, and `relativeReference` still control lookup within the mapping. */
   templates?: {[key: string]: string};
   /** the global scope passed down to all partial and layout templates, i.e. templates included by `include`, `layout` and `render` tags. */
   globals?: object;
@@ -213,6 +213,7 @@ export function normalize (options: LiquidOptions): NormalizedFullOptions {
     options.cache = cache
   }
   options = { ...defaultOptions, ...(options.jekyllInclude ? { dynamicPartials: false } : {}), ...options }
+  if (options.templates) options.fs = new MapFS(options.templates)
   if ((!options.fs!.dirname || !options.fs!.sep) && options.relativeReference) {
     console.warn('[LiquidJS] `fs.dirname` and `fs.sep` are required for relativeReference, set relativeReference to `false` to suppress this warning')
     options.relativeReference = false
@@ -223,11 +224,6 @@ export function normalize (options: LiquidOptions): NormalizedFullOptions {
   options.outputEscape = options.outputEscape && getOutputEscapeFunction(options.outputEscape)
   if (!options.locale) {
     options.locale = getDateTimeFormat()?.().resolvedOptions().locale ?? 'en-US'
-  }
-  if (options.templates) {
-    options.fs = new MapFS(options.templates)
-    options.relativeReference = true
-    options.root = options.partials = options.layouts = '.'
   }
   return options as NormalizedFullOptions
 }

--- a/test/integration/liquid/fs-option.spec.ts
+++ b/test/integration/liquid/fs-option.spec.ts
@@ -68,16 +68,54 @@ describe('LiquidOptions#fs', function () {
     })
     expect(engine.renderFileSync('views/entry')).toEqual('header footer')
   })
-  it('should ignore root/layouts/partials', () => {
+  it('should respect relativeReference for in-memory templates', () => {
+    const engine = new Liquid({
+      relativeReference: false,
+      templates: {
+        'views/entry': 'header {% include "../partials/footer" %}',
+        'partials/footer': 'footer'
+      }
+    })
+    expect(() => engine.renderFileSync('views/entry')).toThrow('Failed to lookup')
+  })
+  it('should respect root/layouts/partials', () => {
     const engine = new Liquid({
       root: '/foo/bar/',
       layouts: '/foo/bar/',
       partials: '/foo/bar/',
       templates: {
-        entry: '{% layout "main" %}entry',
-        main: 'header {% block %}{% endblock %} footer'
+        '/foo/bar/entry': '{% layout "main" %}entry',
+        '/foo/bar/main': 'header {% block %}{% endblock %} footer'
       }
     })
     expect(engine.renderFileSync('entry')).toEqual('header entry footer')
+  })
+  it('should reject dynamic includes outside configured partials', async () => {
+    const engine = new Liquid({
+      root: 'tenant_a',
+      partials: 'tenant_a',
+      templates: {
+        'tenant_a/page.liquid': '{% include filename %}',
+        'tenant_b/secret.liquid': 'B_SECRETS'
+      }
+    })
+    await expect(engine.renderFile('page.liquid', { filename: '../tenant_b/secret.liquid' }))
+      .rejects.toThrow('Failed to lookup')
+    expect(() => engine.renderFileSync('page.liquid', { filename: '../tenant_b/secret.liquid' }))
+      .toThrow('Failed to lookup')
+  })
+  it('should reject dynamic renders outside configured partials', async () => {
+    const engine = new Liquid({
+      root: 'tenant_a',
+      partials: 'tenant_a',
+      templates: {
+        'tenant_a/page.liquid': '{% render filename %}',
+        'tenant_b/secret.liquid': 'B_SECRETS'
+      }
+    })
+    await expect(engine.renderFile('page.liquid', { filename: '../tenant_b/secret.liquid' }))
+      .rejects.toThrow('Failed to lookup')
+    expect(() => engine.renderFileSync('page.liquid', { filename: '../tenant_b/secret.liquid' }))
+      .toThrow('Failed to lookup')
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `MapFS.contains`/`containsSync` so in-memory template lookups honor configured roots
- keep explicit `root`/`layouts`/`partials`/`relativeReference` options when `templates` is used
- add regression coverage for dynamic include/render cross-root lookups

## Testing
- `npm test -- src/fs/map-fs.spec.ts test/integration/liquid/fs-option.spec.ts`
- `npm run build`
- `npm test`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbc7af73-a2dd-400f-843b-ac70063e1b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbc7af73-a2dd-400f-843b-ac70063e1b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

