### PR TITLE
fix(security): charge pop filter allocation to memoryLimit

### DIFF
--- a/src/filters/array.ts
+++ b/src/filters/array.ts
@@ -88,8 +88,10 @@ export function unshift<T> (this: FilterImpl, v: T[], arg: T): T[] {
   return clone
 }
 
-export function pop<T> (v: T[]): T[] {
-  const clone = [...toArray(v)]
+export function pop<T> (this: FilterImpl, v: T[]): T[] {
+  const array = toArray(v)
+  this.context.memoryLimit.use(array.length)
+  const clone = [...array]
   clone.pop()
   return clone
 }

--- a/src/filters/array.ts
+++ b/src/filters/array.ts
@@ -254,7 +254,7 @@ export function sample<T> (this: FilterImpl, v: T[] | string, count = 1): T | st
   v = toValue(v)
   if (isNil(v)) return []
   if (!isArray(v)) v = stringify(v)
-  this.context.memoryLimit.use(count)
+  this.context.memoryLimit.use(v.length)
   const shuffled = [...v].sort(() => Math.random() - 0.5)
   if (count === 1) return shuffled[0]
   return shuffled.slice(0, count)

--- a/test/integration/liquid/dos.spec.ts
+++ b/test/integration/liquid/dos.spec.ts
@@ -79,6 +79,11 @@ describe('DoS related', function () {
       await expect(liquid.parseAndRender(src, { array, count: 3 })).resolves.toBe('a a a a a a a a')
       await expect(liquid.parseAndRender(src, { array, count: 100 })).rejects.toThrow('memory alloc limit exceeded, line:1, col:26')
     })
+    it('should charge pop allocation to memoryLimit', async () => {
+      const array = Array(1e3).fill(0)
+      const liquid = new Liquid({ memoryLimit: 100 })
+      await expect(liquid.parseAndRender('{{ array | pop | size }}', { array })).rejects.toThrow('memory alloc limit exceeded')
+    })
     it('should charge strip_html input length to memoryLimit', () => {
       const liquid = new Liquid({ memoryLimit: 100 })
       expect(() => liquid.parseAndRenderSync('{{ s | strip_html }}', { s: 'a'.repeat(200) }))

--- a/test/integration/liquid/dos.spec.ts
+++ b/test/integration/liquid/dos.spec.ts
@@ -84,6 +84,11 @@ describe('DoS related', function () {
       const liquid = new Liquid({ memoryLimit: 100 })
       await expect(liquid.parseAndRender('{{ array | pop | size }}', { array })).rejects.toThrow('memory alloc limit exceeded')
     })
+    it('should charge sample allocation to memoryLimit', async () => {
+      const array = Array(1e3).fill(0)
+      const liquid = new Liquid({ memoryLimit: 100 })
+      await expect(liquid.parseAndRender('{{ array | sample: 1 | size }}', { array })).rejects.toThrow('memory alloc limit exceeded')
+    })
     it('should charge strip_html input length to memoryLimit', () => {
       const liquid = new Liquid({ memoryLimit: 100 })
       expect(() => liquid.parseAndRenderSync('{{ s | strip_html }}', { s: 'a'.repeat(200) }))


### PR DESCRIPTION
The `pop` array filter cloned the input via `[...toArray(v)]` without charging `this.context.memoryLimit.use(...)`, bypassing the memoryLimit DoS guard that its sibling filters (shift, unshift, compact, etc.) apply. Mirror `shift` to account for the O(N) allocation.