### PR TITLE
perf(parser): memoize createTrie to avoid rebuilding tries per Tokenizer

### DIFF
--- a/src/parser/tokenizer.spec.ts
+++ b/src/parser/tokenizer.spec.ts
@@ -522,6 +522,14 @@ describe('Tokenizer', function () {
       expect(new Tokenizer('contains b').matchTrie(opTrie)).toBe(8)
     })
   })
+  describe('#createTrie()', function () {
+    it('should return the same trie for the same input', () => {
+      expect(createTrie(defaultOperators)).toBe(createTrie(defaultOperators))
+    })
+    it('should return distinct tries for distinct inputs', () => {
+      expect(createTrie({ foo: 1 })).not.toBe(createTrie({ foo: 1 }))
+    })
+  })
   describe('#readLiquidTagTokens', () => {
     it('should read newline terminated tokens', () => {
       const tokenizer = new Tokenizer('echo \'hello\'')

--- a/src/util/operator-trie.ts
+++ b/src/util/operator-trie.ts
@@ -10,7 +10,16 @@ export type Trie<T> = {
   needBoundary?: true
 } & Record<string, any>
 
+// Tries are built once per input object and reused: the Tokenizer rebuilds them
+// on every instantiation, but `input` (operators/literalValues) is a stable
+// reference. WeakMap-keying by `input` lets short-lived operator objects (and
+// their tries) be garbage collected. The returned trie is treated as read-only
+// by callers (matchTrie only reads it); do not mutate it.
+const trieCache = new WeakMap<TrieInput<any>, Trie<any>>()
+
 export function createTrie<T = any> (input: TrieInput<T>): Trie<T> {
+  const cached = trieCache.get(input)
+  if (cached) return cached
   const trie: Trie<T> = {}
   for (const [name, data] of Object.entries(input)) {
     let node = trie
@@ -29,5 +38,6 @@ export function createTrie<T = any> (input: TrieInput<T>): Trie<T> {
     node.data = data
     node.end = true
   }
+  trieCache.set(input, trie)
   return trie
 }


### PR DESCRIPTION
## What

Memoize `createTrie` (`src/util/operator-trie.ts`) with a module-level `WeakMap` keyed on the input object, so the prefix-tries are built once per input and reused across `Tokenizer` instances.

## Why

The `Tokenizer` constructor calls `createTrie(operators)` and `createTrie(literalValues)` on **every** instantiation, and LiquidJS constructs a fresh `Tokenizer` per output/tag while parsing a template. On a typical template this rebuilds the identical tries dozens of times per parse, and the rebuild shows up as a significant share of parse CPU in profiling.

## Why this is safe

- The inputs are **stable references**: `literalValues` is a module-level constant, and `options.operators` is set once per `Liquid` instance.
- The trie is only ever **read** afterward (via `matchTrie`), never mutated, so caching by reference is behavior-preserving.
- `WeakMap` (not `Map`) is used so that short-lived, per-instance operator objects (e.g. the `{}` literal passed in `Hash`), and their tries can be garbage collected. No unbounded growth.
- A comment documents that the returned trie must be treated as read-only, since `createTrie` is re-exported from `src/index.ts` (public API).

## Benchmarks

Built with `npm run build:cjs` and compared against `liquidjs@10.27.0` from unpkg, on `benchmark/templates/todolist.liquid` (arm64, Node, 5s windows):

| Path | latest 10.27.0 | local (this PR) | change |
|---|---|---|---|
| **parse** (`engine.parse`) | 18,807 parse/s (53.2 µs) | 37,194 parse/s (26.9 µs) | **+97.8% (~2x)** |
| **render** (`npm run perf:diff`) | 24,996 ops/s | 25,008 ops/s | +0.047% (noise) |

The official `perf:diff` harness parses the template once outside the timed loop and only times `render`, so it (correctly) shows no change for a parse-path optimization, i.e. no render regression. The render path is unaffected; the win is in parse/`engine.parse`, which the table above isolates.

## Tests

- Added a `#createTrie()` block in `src/parser/tokenizer.spec.ts` asserting that the same input returns the same trie reference and distinct inputs return distinct tries.
