### PR TITLE
fix(security): reject render/include partial recursion

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -103,7 +103,7 @@ export class Context {
     return this.scopes[0]
   }
   public spawn (scope = {}) {
-    return new Context(scope, this.opts, {
+    const ctx = new Context(scope, this.opts, {
       sync: this.sync,
       globals: this.globals,
       strictVariables: this.strictVariables,
@@ -112,6 +112,8 @@ export class Context {
       renderLimit: this.renderLimit,
       memoryLimit: this.memoryLimit
     })
+    ctx.setRegister('partialStack', this.getRegister('partialStack', [] as string[]))
+    return ctx
   }
   private findScope (key: string | number) {
     for (let i = this.scopes.length - 1; i >= 0; i--) {

--- a/src/tags/include.ts
+++ b/src/tags/include.ts
@@ -3,7 +3,7 @@ import { BlockMode, createScope, Scope } from '../context'
 import { Parser } from '../parser'
 import { Argument, Arguments, PartialScope } from '../template'
 import { isString, isValueToken } from '../util'
-import { parseFilePath, renderFilePath, ParsedFileName } from './render'
+import { parseFilePath, renderFilePath, ParsedFileName, pushPartialStack, popPartialStack } from './render'
 
 export default class extends Tag {
   private file: ParsedFileName
@@ -33,16 +33,21 @@ export default class extends Tag {
     const filepath = (yield renderFilePath(this.file, ctx, liquid)) as string
     assert(filepath, () => `illegal file path "${filepath}"`)
 
+    pushPartialStack(ctx, filepath, 'include')
     const saved = ctx.saveRegister('blocks', 'blockMode')
-    ctx.setRegister('blocks', {})
-    ctx.setRegister('blockMode', BlockMode.OUTPUT)
-    const scope = createScope((yield hash.render(ctx)) as Scope)
-    if (withVar) scope[filepath] = yield evalToken(withVar, ctx)
-    const templates = (yield liquid._parsePartialFile(filepath, ctx.sync, this.currentFile)) as Template[]
-    ctx.push(ctx.opts.jekyllInclude ? createScope({ include: scope }) : scope)
-    yield renderer.renderTemplates(templates, ctx, emitter)
-    ctx.pop()
-    ctx.restoreRegister(saved)
+    try {
+      ctx.setRegister('blocks', {})
+      ctx.setRegister('blockMode', BlockMode.OUTPUT)
+      const scope = createScope((yield hash.render(ctx)) as Scope)
+      if (withVar) scope[filepath] = yield evalToken(withVar, ctx)
+      const templates = (yield liquid._parsePartialFile(filepath, ctx.sync, this.currentFile)) as Template[]
+      ctx.push(ctx.opts.jekyllInclude ? createScope({ include: scope }) : scope)
+      yield renderer.renderTemplates(templates, ctx, emitter)
+      ctx.pop()
+    } finally {
+      ctx.restoreRegister(saved)
+      popPartialStack(ctx)
+    }
   }
 
   public * children (partials: boolean, sync: boolean): Generator<unknown, Template[]> {

--- a/src/tags/render.ts
+++ b/src/tags/render.ts
@@ -59,27 +59,32 @@ export default class extends Tag {
     const filepath = (yield renderFilePath(this.file, ctx, liquid)) as string
     assert(filepath, () => `illegal file path "${filepath}"`)
 
-    const childCtx = ctx.spawn()
-    const scope = childCtx.bottom()
-    __assign(scope, yield hash.render(ctx))
-    if (this.with) {
-      const { value, alias } = this.with
-      scope[alias || filepath] = yield evalToken(value, ctx)
-    }
+    pushPartialStack(ctx, filepath, 'render')
+    try {
+      const childCtx = ctx.spawn()
+      const scope = childCtx.bottom()
+      __assign(scope, yield hash.render(ctx))
+      if (this.with) {
+        const { value, alias } = this.with
+        scope[alias || filepath] = yield evalToken(value, ctx)
+      }
 
-    if (this.forBinding) {
-      const { value, alias } = this.forBinding
-      const collection = toEnumerable(yield evalToken(value, ctx))
-      scope['forloop'] = new ForloopDrop(collection.length, value.getText(), alias as string)
-      for (const item of collection) {
-        scope[alias as string] = item
+      if (this.forBinding) {
+        const { value, alias } = this.forBinding
+        const collection = toEnumerable(yield evalToken(value, ctx))
+        scope['forloop'] = new ForloopDrop(collection.length, value.getText(), alias as string)
+        for (const item of collection) {
+          scope[alias as string] = item
+          const templates = (yield liquid._parsePartialFile(filepath, childCtx.sync, this.currentFile)) as Template[]
+          yield liquid.renderer.renderTemplates(templates, childCtx, emitter)
+          scope['forloop'].next()
+        }
+      } else {
         const templates = (yield liquid._parsePartialFile(filepath, childCtx.sync, this.currentFile)) as Template[]
         yield liquid.renderer.renderTemplates(templates, childCtx, emitter)
-        scope['forloop'].next()
       }
-    } else {
-      const templates = (yield liquid._parsePartialFile(filepath, childCtx.sync, this.currentFile)) as Template[]
-      yield liquid.renderer.renderTemplates(templates, childCtx, emitter)
+    } finally {
+      popPartialStack(ctx)
     }
   }
 
@@ -172,4 +177,15 @@ export function * renderFilePath (file: ParsedFileName, ctx: Context, liquid: Li
   if (typeof file === 'string') return file
   if (Array.isArray(file)) return liquid.renderer.renderTemplates(file, ctx)
   return yield evalToken(file, ctx)
+}
+
+export function pushPartialStack (ctx: Context, filepath: string, tag: 'render' | 'include') {
+  const stack: string[] = ctx.getRegister('partialStack', [])
+  if (stack.includes(filepath)) throw new Error(`${tag} tag cannot be nested`)
+  stack.push(filepath)
+}
+
+export function popPartialStack (ctx: Context) {
+  const stack: string[] = ctx.getRegister('partialStack', [])
+  stack.pop()
 }

--- a/src/tags/render.ts
+++ b/src/tags/render.ts
@@ -181,7 +181,9 @@ export function * renderFilePath (file: ParsedFileName, ctx: Context, liquid: Li
 
 export function pushPartialStack (ctx: Context, filepath: string, tag: 'render' | 'include') {
   const stack: string[] = ctx.getRegister('partialStack', [])
-  if (stack.includes(filepath)) throw new Error(`${tag} tag cannot be nested`)
+  if (ctx.renderLimit.isUnlimited() && stack.includes(filepath)) {
+    throw new Error(`${tag} tag cannot be nested`)
+  }
   stack.push(filepath)
 }
 

--- a/src/util/limiter.ts
+++ b/src/util/limiter.ts
@@ -19,4 +19,7 @@ export class Limiter {
       assert(+count <= this.limit, this.message)
     }
   }
+  isUnlimited () {
+    return !Number.isFinite(this.limit)
+  }
 }

--- a/test/e2e/parse-and-render.spec.ts
+++ b/test/e2e/parse-and-render.spec.ts
@@ -133,5 +133,9 @@ describe('.parseAndRender()', function () {
         rmSync(root, { recursive: true, force: true })
       }
     })
+    it('should allow self-referential {% render %} when renderLimit is finite', async function () {
+      const liquid = new Liquid({ templates: { self: '{% render "self" %}' }, renderLimit: 0.01 })
+      await expect(liquid.parseAndRender('{% render "self" %}')).rejects.toThrow(/template render limit exceeded/)
+    })
   })
 })

--- a/test/e2e/parse-and-render.spec.ts
+++ b/test/e2e/parse-and-render.spec.ts
@@ -117,4 +117,21 @@ describe('.parseAndRender()', function () {
       await expect(liquid.renderFile('template')).rejects.toThrow(/block tag cannot be nested/)
     })
   })
+  describe('render/include: self-referential partial regression', function () {
+    it('should reject self-referential {% render %} via in-memory templates (no hang / OOM)', async function () {
+      const liquid = new Liquid({ templates: { self: '{% render "self" %}' } })
+      await expect(liquid.parseAndRender('{% render "self" %}')).rejects.toThrow(/render tag cannot be nested/)
+    })
+    it('should reject self-referential {% include %} (no hang / OOM)', async function () {
+      let root: string
+      root = mkdtempSync(join(tmpdir(), 'liquid-e2e-include-nested-'))
+      try {
+        writeFileSync(join(root, 'self.html'), 'A{% include "self.html" %}B')
+        const liquid = new Liquid({ root, extname: '.html' })
+        await expect(liquid.renderFile('self')).rejects.toThrow(/include tag cannot be nested/)
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+  })
 })

--- a/test/integration/tags/include.spec.ts
+++ b/test/integration/tags/include.spec.ts
@@ -311,6 +311,13 @@ describe('tags/include', function () {
       })
       return expect(liquid.renderFile('/a.html')).rejects.toThrow(/include tag cannot be nested/)
     })
+    it('should allow self-referential {% include %} when renderLimit is finite', function () {
+      mock({
+        '/self.html': 'A{% include "self.html" %}B'
+      })
+      const limited = new Liquid({ root: '/', renderLimit: 0.01 })
+      return expect(limited.renderFile('/self.html')).rejects.toThrow(/template render limit exceeded/)
+    })
     it('should allow legitimate nested {% include %} chain', async function () {
       mock({
         '/a.html': 'A{% include "b.html" %}',

--- a/test/integration/tags/include.spec.ts
+++ b/test/integration/tags/include.spec.ts
@@ -296,4 +296,29 @@ describe('tags/include', function () {
       return expect(html).toBe('FOO-')
     })
   })
+
+  describe('recursion', function () {
+    it('should reject self-referential {% include %} (no OOM / hang)', function () {
+      mock({
+        '/self.html': 'A{% include "self.html" %}B'
+      })
+      return expect(liquid.renderFile('/self.html')).rejects.toThrow(/include tag cannot be nested/)
+    })
+    it('should reject indirect {% include %} cycle (no OOM / hang)', function () {
+      mock({
+        '/a.html': '{% include "b.html" %}',
+        '/b.html': '{% include "a.html" %}'
+      })
+      return expect(liquid.renderFile('/a.html')).rejects.toThrow(/include tag cannot be nested/)
+    })
+    it('should allow legitimate nested {% include %} chain', async function () {
+      mock({
+        '/a.html': 'A{% include "b.html" %}',
+        '/b.html': 'B{% include "c.html" %}',
+        '/c.html': 'C'
+      })
+      const html = await liquid.renderFile('/a.html')
+      expect(html).toBe('ABC')
+    })
+  })
 })

--- a/test/integration/tags/render.spec.ts
+++ b/test/integration/tags/render.spec.ts
@@ -394,4 +394,27 @@ describe('tags/render', function () {
       expect(html).toBe('Xchild with redY')
     })
   })
+
+  describe('recursion', function () {
+    it('should reject self-referential {% render %} via in-memory templates (no OOM / hang)', async function () {
+      const liquid = new Liquid({ templates: { self: '{% render "self" %}' } })
+      await expect(liquid.parseAndRender('{% render "self" %}')).rejects.toThrow(/render tag cannot be nested/)
+    })
+    it('should reject indirect {% render %} cycle (no OOM / hang)', async function () {
+      mock({
+        '/a.html': '{% render "b.html" %}',
+        '/b.html': '{% render "a.html" %}'
+      })
+      await expect(liquid.renderFile('/a.html')).rejects.toThrow(/render tag cannot be nested/)
+    })
+    it('should allow legitimate nested {% render %} chain', async function () {
+      mock({
+        '/a.html': 'A{% render "b.html" %}',
+        '/b.html': 'B{% render "c.html" %}',
+        '/c.html': 'C'
+      })
+      const html = await liquid.renderFile('/a.html')
+      expect(html).toBe('ABC')
+    })
+  })
 })

--- a/test/integration/tags/render.spec.ts
+++ b/test/integration/tags/render.spec.ts
@@ -407,6 +407,10 @@ describe('tags/render', function () {
       })
       await expect(liquid.renderFile('/a.html')).rejects.toThrow(/render tag cannot be nested/)
     })
+    it('should allow self-referential {% render %} when renderLimit is finite', async function () {
+      const liquid = new Liquid({ templates: { self: '{% render "self" %}' }, renderLimit: 0.01 })
+      await expect(liquid.parseAndRender('{% render "self" %}')).rejects.toThrow(/template render limit exceeded/)
+    })
     it('should allow legitimate nested {% render %} chain', async function () {
       mock({
         '/a.html': 'A{% render "b.html" %}',


### PR DESCRIPTION
Detect cyclic partial rendering via a shared partialStack register (same pattern as CVE-2026-41311 block tag fix). Self-referential or circular {% render %} and {% include %} now throw immediately instead of hanging or OOM.