### PR TITLE
docs(security): route vulnerability reports to GitHub Advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,10 @@ Only the latest major version is supported with security updates. It can be chan
 
 ## Reporting a Vulnerability
 
-Please contact harttleharttle@gmail.com to report a vulnerability or change request.
+**Please do not report security vulnerabilities through public GitHub issues.**
 
-- If the vulnerability in question affects common use cases, it will be treated as a bug and fixed very soon (typically within 1 week).
+Report them via [GitHub Security Advisories — Report a vulnerability](https://github.com/harttle/liquidjs/security/advisories/new).
+
+- If the vulnerability in question affects common use cases, it will be treated as a bug and fixed very soon (typically within a month).
 - Otherwise, it'll be scheduled in the same priority of feature request (which is lower than bugs).
-- If the request is declined, you'll receive a reply email anyway (most likely there will be a discussion).
+- If the request is declined, you'll receive a reply anyway (most likely there will be a discussion).


### PR DESCRIPTION
## Summary
- Update `SECURITY.md` to direct reporters to GitHub Security Advisories instead of a private email
- Ask reporters not to open public GitHub issues for security vulnerabilities
- Set the common-use-case fix expectation to within a month

## Test plan
- [x] Review `SECURITY.md` rendering on GitHub Security tab
- [ ] Confirm Private vulnerability reporting is enabled in repo settings