### PR TITLE
feat(v11)!: restrict size/first/last magic keys to arrays and strings

### DIFF
--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -183,6 +183,48 @@ describe('Context', function () {
       ctx.push({ foo: Object.create({ bar: 'BAR' }) })
       return expect(() => ctx.getSync(['foo', 'bar'])).toThrow(/undefined variable: foo.bar/)
     })
+    it('should block prototype size/first/last magic keys', function () {
+      Object.assign(Object.prototype, { size: 123, first: 'FIRST_PROTO', last: 'LAST_PROTO' })
+      try {
+        ctx.push({ foo: {} })
+        expect(ctx.getSync(['foo', 'size'])).toEqual(0)
+        expect(ctx.getSync(['foo', 'first'])).toEqual(undefined)
+        expect(ctx.getSync(['foo', 'last'])).toEqual(undefined)
+      } finally {
+        delete (Object.prototype as any).size
+        delete (Object.prototype as any).first
+        delete (Object.prototype as any).last
+      }
+    })
+    it('should allow array first/last/size magic keys with ownPropertyOnly', function () {
+      ctx.push({ foo: [1, 2, 3] })
+      expect(ctx.getSync(['foo', 'first'])).toEqual(1)
+      expect(ctx.getSync(['foo', 'last'])).toEqual(3)
+      expect(ctx.getSync(['foo', 'size'])).toEqual(3)
+    })
+    it('should use prototype magic keys when ownPropertyOnly=false', function () {
+      Object.assign(Object.prototype, { size: 123, first: 'FIRST_PROTO', last: 'LAST_PROTO' })
+      try {
+        ctx = new Context({}, { ownPropertyOnly: false } as any)
+        ctx.push({ foo: {} })
+        expect(ctx.getSync(['foo', 'size'])).toEqual(123)
+        expect(ctx.getSync(['foo', 'first'])).toEqual('FIRST_PROTO')
+        expect(ctx.getSync(['foo', 'last'])).toEqual('LAST_PROTO')
+      } finally {
+        delete (Object.prototype as any).size
+        delete (Object.prototype as any).first
+        delete (Object.prototype as any).last
+      }
+    })
+    it('should treat bracket access like dot access for magic keys', function () {
+      Object.assign(Object.prototype, { size: 123 })
+      try {
+        ctx.push({ foo: {} })
+        expect(ctx.getSync(['foo', 'size'])).toEqual(0)
+      } finally {
+        delete (Object.prototype as any).size
+      }
+    })
   })
 
   describe('.getAll()', function () {

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -32,7 +32,7 @@ describe('Context', function () {
     it('should read nested property', async function () {
       expect(ctx.get(['obj', 'first'])).toEqual('f')
       expect(ctx.get(['obj', 'last'])).toEqual('l')
-      expect(ctx.get(['obj', 'size'])).toEqual(2)
+      expect(ctx.get(['obj', 'size'])).toBeUndefined()
     })
     it('undefined property should yield undefined', async function () {
       expect(ctx.get(['notdefined'])).toEqual(undefined)
@@ -55,7 +55,9 @@ describe('Context', function () {
     it('should return array length as size', async function () {
       expect(ctx.get(['bar', 'arr', 'size'])).toEqual(2)
     })
-    it('should return map size as size', async function () {
+    it('should return map size only via own property access', async function () {
+      expect(ctx.get(['map', 'size'])).toBeUndefined()
+      ctx = new Context(scope, { ownPropertyOnly: false } as any)
       expect(ctx.get(['map', 'size'])).toEqual(1)
     })
     it('should return undefined if not have a size', async function () {
@@ -67,6 +69,14 @@ describe('Context', function () {
     })
     it('should read .last of array', async function () {
       expect(ctx.get(['bar', 'arr', 'last'])).toEqual('b')
+    })
+    it('should read own size property on objects', async function () {
+      expect(ctx.get(['zoo', 'size'])).toEqual(4)
+    })
+    it('should read string first/last as magic keys', async function () {
+      ctx.push({ str: 'abc' })
+      expect(ctx.getSync(['str', 'first'])).toEqual('a')
+      expect(ctx.getSync(['str', 'last'])).toEqual('c')
     })
     it('should read element of array', async function () {
       expect(ctx.get(['arr', 1])).toEqual('b')
@@ -167,13 +177,16 @@ describe('Context', function () {
       ctx.push({ foo: [1, 2] })
       return expect(ctx.getSync(['foo', 'size'])).toEqual(2)
     })
-    it('should allow size to access Set.prototype.size', function () {
+    it('should allow size to access Set.prototype.size via property access', function () {
+      ctx.push({ foo: new Set([1, 2]) })
+      expect(ctx.getSync(['foo', 'size'])).toEqual(undefined)
+      ctx = new Context({}, { ownPropertyOnly: false } as any)
       ctx.push({ foo: new Set([1, 2]) })
       return expect(ctx.getSync(['foo', 'size'])).toEqual(2)
     })
-    it('should allow size to access Object key count', function () {
+    it('should not apply size magic to plain objects', function () {
       ctx.push({ foo: { bar: 'BAR', coo: 'COO' } })
-      return expect(ctx.getSync(['foo', 'size'])).toEqual(2)
+      return expect(ctx.getSync(['foo', 'size'])).toEqual(undefined)
     })
     it('should throw when property is hidden and strictVariables is true', function () {
       ctx = new Context(ctx, {
@@ -183,11 +196,11 @@ describe('Context', function () {
       ctx.push({ foo: Object.create({ bar: 'BAR' }) })
       return expect(() => ctx.getSync(['foo', 'bar'])).toThrow(/undefined variable: foo.bar/)
     })
-    it('should block prototype size/first/last magic keys', function () {
+    it('should not apply size/first/last magic keys to plain objects', function () {
       Object.assign(Object.prototype, { size: 123, first: 'FIRST_PROTO', last: 'LAST_PROTO' })
       try {
         ctx.push({ foo: {} })
-        expect(ctx.getSync(['foo', 'size'])).toEqual(0)
+        expect(ctx.getSync(['foo', 'size'])).toEqual(undefined)
         expect(ctx.getSync(['foo', 'first'])).toEqual(undefined)
         expect(ctx.getSync(['foo', 'last'])).toEqual(undefined)
       } finally {
@@ -196,13 +209,13 @@ describe('Context', function () {
         delete (Object.prototype as any).last
       }
     })
-    it('should allow array first/last/size magic keys with ownPropertyOnly', function () {
+    it('should allow array first/last/size magic keys', function () {
       ctx.push({ foo: [1, 2, 3] })
       expect(ctx.getSync(['foo', 'first'])).toEqual(1)
       expect(ctx.getSync(['foo', 'last'])).toEqual(3)
       expect(ctx.getSync(['foo', 'size'])).toEqual(3)
     })
-    it('should use prototype magic keys when ownPropertyOnly=false', function () {
+    it('should read prototype size/first/last via property access when ownPropertyOnly=false', function () {
       Object.assign(Object.prototype, { size: 123, first: 'FIRST_PROTO', last: 'LAST_PROTO' })
       try {
         ctx = new Context({}, { ownPropertyOnly: false } as any)

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -216,15 +216,6 @@ describe('Context', function () {
         delete (Object.prototype as any).last
       }
     })
-    it('should treat bracket access like dot access for magic keys', function () {
-      Object.assign(Object.prototype, { size: 123 })
-      try {
-        ctx.push({ foo: {} })
-        expect(ctx.getSync(['foo', 'size'])).toEqual(0)
-      } finally {
-        delete (Object.prototype as any).size
-      }
-    })
   })
 
   describe('.getAll()', function () {

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -129,9 +129,9 @@ export class Context {
     const value = readJSProperty(obj, key, this.ownPropertyOnly)
     if (value === undefined && obj instanceof Drop) return obj.liquidMethodMissing(key, this)
     if (isFunction(value)) return value.call(obj)
-    if (key === 'size') return readSize(obj, this.ownPropertyOnly)
-    else if (key === 'first') return readFirst(obj, this.ownPropertyOnly)
-    else if (key === 'last') return readLast(obj, this.ownPropertyOnly)
+    if (key === 'size' && (isArray(obj) || isString(obj))) return readSize(obj)
+    else if (key === 'first' && (isArray(obj) || isString(obj))) return readFirst(obj)
+    else if (key === 'last' && (isArray(obj) || isString(obj))) return readLast(obj)
     return value
   }
 }
@@ -141,22 +141,16 @@ export function readJSProperty (obj: Scope, key: PropertyKey, ownPropertyOnly: b
   return obj[key]
 }
 
-function readFirst (obj: Scope, ownPropertyOnly: boolean) {
+function readFirst (obj: Scope) {
   if (isArray(obj)) return obj[0]
-  if (ownPropertyOnly && !hasOwnProperty.call(obj, 'first') && !(obj instanceof Drop)) return undefined
-  return obj['first']
+  return obj[0]
 }
 
-function readLast (obj: Scope, ownPropertyOnly: boolean) {
+function readLast (obj: Scope) {
   if (isArray(obj)) return obj[obj.length - 1]
-  if (ownPropertyOnly && !hasOwnProperty.call(obj, 'last') && !(obj instanceof Drop)) return undefined
-  return obj['last']
+  return obj[obj.length - 1]
 }
 
-function readSize (obj: Scope, ownPropertyOnly: boolean) {
-  if (hasOwnProperty.call(obj, 'size')) return obj['size']
-  if (!ownPropertyOnly && obj['size'] !== undefined) return obj['size']
-  if (isArray(obj) || isString(obj)) return obj.length
-  if (obj instanceof Set || obj instanceof Map) return obj.size
-  if (typeof obj === 'object') return Object.keys(obj).length
+function readSize (obj: Scope) {
+  return obj.length
 }

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -129,9 +129,9 @@ export class Context {
     const value = readJSProperty(obj, key, this.ownPropertyOnly)
     if (value === undefined && obj instanceof Drop) return obj.liquidMethodMissing(key, this)
     if (isFunction(value)) return value.call(obj)
-    if (key === 'size') return readSize(obj)
-    else if (key === 'first') return readFirst(obj)
-    else if (key === 'last') return readLast(obj)
+    if (key === 'size') return readSize(obj, this.ownPropertyOnly)
+    else if (key === 'first') return readFirst(obj, this.ownPropertyOnly)
+    else if (key === 'last') return readLast(obj, this.ownPropertyOnly)
     return value
   }
 }
@@ -141,18 +141,22 @@ export function readJSProperty (obj: Scope, key: PropertyKey, ownPropertyOnly: b
   return obj[key]
 }
 
-function readFirst (obj: Scope) {
+function readFirst (obj: Scope, ownPropertyOnly: boolean) {
   if (isArray(obj)) return obj[0]
+  if (ownPropertyOnly && !hasOwnProperty.call(obj, 'first') && !(obj instanceof Drop)) return undefined
   return obj['first']
 }
 
-function readLast (obj: Scope) {
+function readLast (obj: Scope, ownPropertyOnly: boolean) {
   if (isArray(obj)) return obj[obj.length - 1]
+  if (ownPropertyOnly && !hasOwnProperty.call(obj, 'last') && !(obj instanceof Drop)) return undefined
   return obj['last']
 }
 
-function readSize (obj: Scope) {
-  if (hasOwnProperty.call(obj, 'size') || obj['size'] !== undefined) return obj['size']
+function readSize (obj: Scope, ownPropertyOnly: boolean) {
+  if (hasOwnProperty.call(obj, 'size')) return obj['size']
+  if (!ownPropertyOnly && obj['size'] !== undefined) return obj['size']
   if (isArray(obj) || isString(obj)) return obj.length
+  if (obj instanceof Set || obj instanceof Map) return obj.size
   if (typeof obj === 'object') return Object.keys(obj).length
 }

--- a/test/e2e/issues.spec.ts
+++ b/test/e2e/issues.spec.ts
@@ -215,6 +215,21 @@ describe('Issues', function () {
     const html = engine.parseAndRenderSync('{{foo | size}}-{{bar.coo}}', { foo: 'foo', bar: Object.create({ coo: 'COO' }) })
     expect(html).toBe('3-')
   })
+  it('should block prototype pollution via size/first/last magic keys', () => {
+    Object.assign(Object.prototype, { size: 123, first: 'FIRST_PROTO', last: 'LAST_PROTO' })
+    try {
+      const engine = new Liquid({ ownPropertyOnly: true })
+      const tpl = '{{ foo.size }}-{{ foo.first }}-{{ foo.last }}-{{ foo["size"] }}'
+      expect(engine.parseAndRenderSync(tpl, { foo: {} })).toBe('0---0')
+      expect(engine.parseAndRenderSync('{{ arr.first }}-{{ arr.last }}-{{ arr.size }}', { arr: [1, 2, 3] })).toBe('1-3-3')
+      const engine2 = new Liquid({ ownPropertyOnly: false })
+      expect(engine2.parseAndRenderSync('{{ foo.size }}-{{ foo.first }}-{{ foo.last }}', { foo: {} })).toBe('123-FIRST_PROTO-LAST_PROTO')
+    } finally {
+      delete (Object.prototype as any).size
+      delete (Object.prototype as any).first
+      delete (Object.prototype as any).last
+    }
+  })
   it('Liquidjs divided_by not compatible with Ruby/Shopify Liquid #465', () => {
     const engine = new Liquid({ ownPropertyOnly: true })
     const html = engine.parseAndRenderSync('{{ 5 | divided_by: 3, true }}')

--- a/test/e2e/issues.spec.ts
+++ b/test/e2e/issues.spec.ts
@@ -215,21 +215,6 @@ describe('Issues', function () {
     const html = engine.parseAndRenderSync('{{foo | size}}-{{bar.coo}}', { foo: 'foo', bar: Object.create({ coo: 'COO' }) })
     expect(html).toBe('3-')
   })
-  it('should block prototype pollution via size/first/last magic keys', () => {
-    Object.assign(Object.prototype, { size: 123, first: 'FIRST_PROTO', last: 'LAST_PROTO' })
-    try {
-      const engine = new Liquid({ ownPropertyOnly: true })
-      const tpl = '{{ foo.size }}-{{ foo.first }}-{{ foo.last }}-{{ foo["size"] }}'
-      expect(engine.parseAndRenderSync(tpl, { foo: {} })).toBe('0---0')
-      expect(engine.parseAndRenderSync('{{ arr.first }}-{{ arr.last }}-{{ arr.size }}', { arr: [1, 2, 3] })).toBe('1-3-3')
-      const engine2 = new Liquid({ ownPropertyOnly: false })
-      expect(engine2.parseAndRenderSync('{{ foo.size }}-{{ foo.first }}-{{ foo.last }}', { foo: {} })).toBe('123-FIRST_PROTO-LAST_PROTO')
-    } finally {
-      delete (Object.prototype as any).size
-      delete (Object.prototype as any).first
-      delete (Object.prototype as any).last
-    }
-  })
   it('Liquidjs divided_by not compatible with Ruby/Shopify Liquid #465', () => {
     const engine = new Liquid({ ownPropertyOnly: true })
     const html = engine.parseAndRenderSync('{{ 5 | divided_by: 3, true }}')


### PR DESCRIPTION
## Summary

**Draft / WIP — planned breaking change for v11.** Related to #916.

- Restrict Liquid magic semantics for `size`, `first`, and `last` to **arrays and strings** only
- Plain objects no longer get `Object.keys` count for `.size` or `obj['first']` / `obj['last']` magic fallbacks
- Map/Set `.size` is no longer resolved via magic (still accessible as a normal property when `ownPropertyOnly: false`)
- Own properties named `size`/`first`/`last` on objects remain accessible via regular property lookup
- Replaces the earlier `ownPropertyOnly` guard approach with simpler, safer semantics

## Breaking changes

| Value type | Before (v10) | After (v11) |
|---|---|---|
| Plain object `{}` | `.size` -> key count | `.size` -> `undefined` |
| Plain object `{}` | `.first`/`.last` -> `obj['first']`/`obj['last']` | `.first`/`.last` -> `undefined` (unless own property) |
| Array / string | magic works | unchanged |
| Map / Set | magic `.size` | `undefined` with default `ownPropertyOnly`; native `.size` when `ownPropertyOnly: false` |

## Test plan

- [x] `npm run build`
- [x] `jest src/context/context.spec.ts`
- [x] `jest test/e2e/issues.spec.ts`

---

Fixes #916

> **Development link:** This keyword ties PR #915 to issue #916 in the Development sidebar. The issue will **automatically close when this PR is merged** into `master`. This PR is **draft / WIP** for v11; do not merge until the v11 breaking change is intended to ship.
