### PR TITLE
fix(strip_html): avoid infinite loop on unclosed openers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage/
 node_modules/
 
 # tmp
+.local/
 docs/themes/navy/source/js/liquid.browser.min.js
 docs/themes/navy/layout/partial/all-contributors.swig
 docs/themes/navy/layout/partial/financial-contributors.swig

--- a/docs/source/filters/strip_html.md
+++ b/docs/source/filters/strip_html.md
@@ -6,6 +6,10 @@ title: strip_html
 
 Removes any HTML tags from a string.
 
+{% note warn Not safe for HTML output %}
+This filter is **not** a sanitizer. Output may still contain `<` sequences (for example malformed tags without a closing `>`, same as [Shopify Liquid](https://shopify.dev/docs/api/liquid/filters/strip_html)). Do not write the result into HTML without also using [escape][escape], [escape_once][escape_once], or [`outputEscape: "escape"`][outputEscape].
+{% endnote %}
+
 Input
 ```liquid
 {{ "Have <em>you</em> read <strong>Ulysses</strong>?" | strip_html }}
@@ -15,3 +19,7 @@ Output
 ```text
 Have you read Ulysses?
 ```
+
+[escape]: ./escape.html
+[escape_once]: ./escape.html
+[outputEscape]: ../tutorials/options.html#outputEscape

--- a/docs/source/filters/strip_html.md
+++ b/docs/source/filters/strip_html.md
@@ -7,7 +7,7 @@ title: strip_html
 Removes any HTML tags from a string.
 
 {% note warn Not safe for HTML output %}
-This filter is **not** a sanitizer. Output may still contain `<` sequences (for example malformed tags without a closing `>`, same as [Shopify Liquid](https://shopify.dev/docs/api/liquid/filters/strip_html)). Do not write the result into HTML without also using [escape][escape], [escape_once][escape_once], or [`outputEscape: "escape"`][outputEscape].
+This filter removes tags by string scanning; it does not parse HTML5 the way a browser does, and it is not a sanitizer. The result may still be unsafe when inserted into HTML. Use [escape][escape], [escape_once][escape_once], or [`outputEscape: "escape"`][outputEscape] for untrusted output.
 {% endnote %}
 
 Input

--- a/src/filters/html.ts
+++ b/src/filters/html.ts
@@ -60,7 +60,7 @@ export function strip_html (this: FilterImpl, v: string) {
       if (e >= 0) { i = e + closer.length; break }
       blocks.delete(opener)
     }
-    if (i === lt) return out + str.slice(lt)
+    if (i <= lt) return out + str.slice(lt)
   }
   return out
 }

--- a/test/integration/filters/html.spec.ts
+++ b/test/integration/filters/html.spec.ts
@@ -85,5 +85,9 @@ describe('filters/html', function () {
       expect(liquid.parseAndRenderSync('{{"<img\rsrc=x\ronerror=alert(1)>" | strip_html}}')).toBe('')
       expect(liquid.parseAndRenderSync('{{"<svg\nonload=alert(1)>" | strip_html}}')).toBe('')
     })
+    it('should not loop on unclosed openers (GHSA-m7fp-h3p4-hr49)', function () {
+      expect(liquid.parseAndRenderSync('{{ "a<" | strip_html }}')).toBe('a<')
+      expect(liquid.parseAndRenderSync('{{ "hello<world<again" | strip_html }}')).toBe('hello<world<again')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes infinite loop / OOM in `strip_html` ([GHSA-m7fp-h3p4-hr49](https://github.com/harttle/liquidjs/security/advisories/GHSA-m7fp-h3p4-hr49)) with a one-line change: stall guard `i === lt` → `i <= lt`.

When text precedes an unclosed `<`, the loop does not advance `i` but the old `i === lt` guard never fired (`i < lt`), so `out` grew forever (e.g. input `a<`).

Also documents that `strip_html` output is not safe for HTML without [escape](https://liquidjs.com/filters/escape.html) / `outputEscape` — it strips by string scanning, not HTML5 parsing (same class of limitation as Shopify Liquid).

## Changes

- `src/filters/html.ts` — one-line stall guard fix
- `test/integration/filters/html.spec.ts` — regression tests for `a<` and `hello<world<again`
- `docs/source/filters/strip_html.md` — not HTML-safe warning
- `.gitignore` — `.local/` for local repro scripts

## Not in scope

- No rewrite to Ruby's two-pass regex model
- No extra hardening of malformed tags (we match Shopify **results**, not impl)
- Pre-existing Ruby result mismatch: `<<<script </script>script>foo;</script>` → Ruby `foo;`, LiquidJS `script>foo;`

## Test plan

- [x] `npm test -- test/integration/filters/html.spec.ts`
- [x] Local vs published: `node .local/strip-html/run-verify.mjs dist/liquid.node.js` (passes) vs CDN 10.27.0 bundle (times out on `a<`)