### PR TITLE
fix(filters): modulo should follow divisor sign for negative operands

### DIFF
--- a/src/filters/math.ts
+++ b/src/filters/math.ts
@@ -8,7 +8,7 @@ export const divided_by = argumentsToNumber((dividend: number, divisor: number, 
 export const floor = argumentsToNumber(Math.floor)
 export const minus = argumentsToNumber((v: number, arg: number) => v - arg)
 export const plus = argumentsToNumber((lhs: number, rhs: number) => lhs + rhs)
-export const modulo = argumentsToNumber((v: number, arg: number) => v % arg)
+export const modulo = argumentsToNumber((v: number, arg: number) => ((v % arg) + arg) % arg)
 export const times = argumentsToNumber((v: number, arg: number) => v * arg)
 
 export function round (v: number, arg = 0) {

--- a/test/integration/filters/math.spec.ts
+++ b/test/integration/filters/math.spec.ts
@@ -50,6 +50,9 @@ describe('filters/math', function () {
       expect(Number(html)).toBeCloseTo(3.357, 3)
     })
     it('should convert string', () => test('{{ "24" | modulo: "7" }}', '3'))
+    it('should follow divisor sign for negative dividend', () => test('{{ -7 | modulo: 3 }}', '2'))
+    it('should follow divisor sign for negative divisor', () => test('{{ 7 | modulo: -3 }}', '-2'))
+    it('should follow divisor sign for negative float', () => test('{{ -4.5 | modulo: 3 }}', '1.5'))
   })
   describe('plus', function () {
     it('should return "6" for 4,2', () => test('{{ 4 | plus: 2 }}', '6'))


### PR DESCRIPTION
## Problem

The `modulo` filter returns the wrong sign for negative operands. liquidjs uses JavaScript's `%` operator, which is a truncated remainder whose sign follows the **dividend**. Shopify's Liquid is Ruby-based, and Ruby's `%` is a floored modulo whose sign follows the **divisor**.

The README states liquidjs is "Shopify, Jekyll and GitHub Pages compatible", so this is an observable compatibility gap:

| Template | Shopify / Ruby (expected) | liquidjs (actual) |
|---|---|---|
| `{{ -7 \| modulo: 3 }}` | `2` | `-1` |
| `{{ 7 \| modulo: -3 }}` | `-2` | `1` |
| `{{ -4.5 \| modulo: 3 }}` | `1.5` | `-1.5` |

## Root cause

`src/filters/math.ts`:

```ts
export const modulo = argumentsToNumber((v, arg) => v % arg)
```

JS `%` is truncated remainder; Ruby `%` (and therefore Shopify Liquid) is floored modulo.

## Fix

```ts
export const modulo = argumentsToNumber((v, arg) => ((v % arg) + arg) % arg)
```

`((v % arg) + arg) % arg` reproduces Ruby's floored result for negative dividends and negative divisors. For non-negative operands the expression is identical to `v % arg`, so existing behavior is preserved, including the documented float case `{{ 183.357 | modulo: 12 }}` which still yields `3.3569999999999993`.

## Verification

Added three cases to `test/integration/filters/math.spec.ts` covering negative dividend, negative divisor, and a negative float. They fail on `master` and pass with the fix. The full suite is green (`npm test`: 1562 passing) and `npm run build` succeeds. All existing positive-operand modulo tests are unchanged.
