### PR TITLE
feat: remove downlevelIteration from Rollup tsconfig override (#905)

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -23,8 +23,7 @@ const tsconfig = (target) => ({
     compilerOptions: {
       target,
       module: 'ES2015',
-      rootDir: 'src',
-      downlevelIteration: true
+      rootDir: 'src'
     }
   }
 })


### PR DESCRIPTION
﻿## Summary

Finishes #905 (ES6 UMD work) by removing the `downlevelIteration` override from the Rollup TypeScript plugin config in `rollup.config.mjs`, relying on the project tsconfig instead.

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`

Closes #905
