### PR TITLE
fix(url_decode): keep %2B as a literal plus when decoding

### DIFF
--- a/src/filters/url.ts
+++ b/src/filters/url.ts
@@ -1,6 +1,6 @@
 import { stringify } from '../util/underscore'
 
-export const url_decode = (x: string) => decodeURIComponent(stringify(x)).replace(/\+/g, ' ')
+export const url_decode = (x: string) => decodeURIComponent(stringify(x).replace(/\+/g, ' '))
 export const url_encode = (x: string) => encodeURIComponent(stringify(x)).replace(/%20/g, '+')
 export const cgi_escape = (x: string) => encodeURIComponent(stringify(x))
   .replace(/%20/g, '+')

--- a/test/integration/filters/url.spec.ts
+++ b/test/integration/filters/url.spec.ts
@@ -7,6 +7,14 @@ describe('filters/url', () => {
       const html = liquid.parseAndRenderSync('{{ "%27Stop%21%27+said+Fred" | url_decode }}')
       expect(html).toEqual("'Stop!' said Fred")
     })
+    it('should decode %2B to a literal plus', () => {
+      const html = liquid.parseAndRenderSync('{{ "1%2B1" | url_decode }}')
+      expect(html).toEqual('1+1')
+    })
+    it('should keep a literal plus when round-tripped through url_encode', () => {
+      const html = liquid.parseAndRenderSync('{{ "a+b c" | url_encode | url_decode }}')
+      expect(html).toEqual('a+b c')
+    })
   })
 
   describe('url_encode', () => {


### PR DESCRIPTION
I noticed that `url_decode` loses a literal `+`: `{{ "1%2B1" | url_decode }}` gives `1 1` instead of `1+1`, and anything with a `+` no longer survives a `url_encode | url_decode` round-trip (`a+b c` comes back as `a b c`).

The cause is ordering: it ran `decodeURIComponent` first and only then replaced every `+` with a space, so a `%2B` decoded to `+` and was immediately turned into a space. I moved the `+`-to-space replacement ahead of `decodeURIComponent`, so encoded pluses survive. This matches Ruby's `CGI.unescape` that Shopify uses.

Tested with two new cases in `test/integration/filters/url.spec.ts` (the `%2B` decode and the round-trip), plus the full suite and lint.