### PR TITLE
feat!: require positional template; drop bare stdin and --template

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ npm install liquidjs
 **CLI**
 
 ```bash
-npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
+npx liquidjs 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
+# or: npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
 ```
 
 See the [setup guide][setup] for partials, layouts, caching, and other options.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ npm install liquidjs
 
 ```bash
 npx liquidjs 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
-# or: npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
 ```
 
 See the [setup guide][setup] for partials, layouts, caching, and other options.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install liquidjs
 **CLI**
 
 ```bash
-npx liquidjs 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
+npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
 ```
 
 See the [setup guide][setup] for partials, layouts, caching, and other options.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install liquidjs
 **CLI**
 
 ```bash
-npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
+npx liquidjs 'Hello, {{ name }}!' --context '{"name": "Liquid"}'
 ```
 
 See the [setup guide][setup] for partials, layouts, caching, and other options.

--- a/bin/liquid.js
+++ b/bin/liquid.js
@@ -14,8 +14,7 @@ async function render () {
   program
     .name('liquidjs')
     .description('Render a Liquid template')
-    .argument('[template]', 'liquid template to render (inline, @path, or @- for stdin)')
-    .option('-t, --template <liquid | @path>', 'liquid template to render (inline, @path, or @- for stdin)')
+    .argument('<template>', 'liquid template to render (inline, @path, or @- for stdin)')
     .option('-c, --context <json | @path>', 'input context in JSON format (inline, @path, or @- for stdin)')
     .option('-o, --output <path>', 'write rendered output to file (omit to write to stdout)')
     .option('--cache [size]', 'cache previously parsed template structures (default cache size: 1024)')
@@ -46,17 +45,7 @@ async function render () {
     .parse()
 
   const options = program.opts()
-  const positionalTemplate = program.args[0]
-  const optionTemplate = options.template
-
-  if (positionalTemplate && optionTemplate && positionalTemplate !== optionTemplate) {
-    throw new Error(`Conflicting templates: positional argument and --template differ.`)
-  }
-
-  const templateOption = positionalTemplate || optionTemplate
-  if (!templateOption) {
-    throw new Error(`A template is required. Pass a positional <template> or --template.`)
-  }
+  const templateOption = program.args[0]
 
   if (Object.values({ template: templateOption, context: options.context }).filter((value) => value === '@-').length > 1) {
     throw new Error(`The stdin input specifier '@-' must only be used once.`)

--- a/bin/liquid.js
+++ b/bin/liquid.js
@@ -14,7 +14,8 @@ async function render () {
   program
     .name('liquidjs')
     .description('Render a Liquid template')
-    .requiredOption('-t, --template <liquid | @path>', 'liquid template to render (inline, @path, or @- for stdin)')
+    .argument('[template]', 'liquid template to render (inline, @path, or @- for stdin)')
+    .option('-t, --template <liquid | @path>', 'liquid template to render (inline, @path, or @- for stdin)')
     .option('-c, --context <json | @path>', 'input context in JSON format (inline, @path, or @- for stdin)')
     .option('-o, --output <path>', 'write rendered output to file (omit to write to stdout)')
     .option('--cache [size]', 'cache previously parsed template structures (default cache size: 1024)')
@@ -45,12 +46,23 @@ async function render () {
     .parse()
 
   const options = program.opts()
+  const positionalTemplate = program.args[0]
+  const optionTemplate = options.template
 
-  if (Object.values(options).filter((value) => value === '@-').length > 1) {
+  if (positionalTemplate && optionTemplate && positionalTemplate !== optionTemplate) {
+    throw new Error(`Conflicting templates: positional argument and --template differ.`)
+  }
+
+  const templateOption = positionalTemplate || optionTemplate
+  if (!templateOption) {
+    throw new Error(`A template is required. Pass a positional <template> or --template.`)
+  }
+
+  if (Object.values({ template: templateOption, context: options.context }).filter((value) => value === '@-').length > 1) {
     throw new Error(`The stdin input specifier '@-' must only be used once.`)
   }
 
-  const template = await resolveInputOption(options.template)
+  const template = await resolveInputOption(templateOption)
   const context = await resolveContext(options.context)
   const liquid = new Liquid(options)
   const output = liquid.parseAndRenderSync(template, context)

--- a/bin/liquid.js
+++ b/bin/liquid.js
@@ -14,8 +14,8 @@ async function render () {
   program
     .name('liquidjs')
     .description('Render a Liquid template')
-    .requiredOption('-t, --template <liquid | @path>', 'liquid template to render (inline or @path to a file)')
-    .option('-c, --context <json | @path>', 'input context in JSON format (@- to read from stdin)')
+    .requiredOption('-t, --template <liquid | @path>', 'liquid template to render (inline, @path, or @- for stdin)')
+    .option('-c, --context <json | @path>', 'input context in JSON format (inline, @path, or @- for stdin)')
     .option('-o, --output <path>', 'write rendered output to file (omit to write to stdout)')
     .option('--cache [size]', 'cache previously parsed template structures (default cache size: 1024)')
     .option('--extname <string>', 'use a default filename extension when resolving partials and layouts')
@@ -45,7 +45,12 @@ async function render () {
     .parse()
 
   const options = program.opts()
-  const template = await resolveTemplate(options.template)
+
+  if (Object.values(options).filter((value) => value === '@-').length > 1) {
+    throw new Error(`The stdin input specifier '@-' must only be used once.`)
+  }
+
+  const template = await resolveInputOption(options.template)
   const context = await resolveContext(options.context)
   const liquid = new Liquid(options)
   const output = liquid.parseAndRenderSync(template, context)
@@ -63,13 +68,6 @@ async function resolveContext (contextOption) {
   }
   const context = JSON.parse(contextJson)
   return context
-}
-
-async function resolveTemplate (templateOption) {
-  if (templateOption && templateOption.startsWith('@') && templateOption !== '@-') {
-    return resolveInputOption(templateOption)
-  }
-  return templateOption
 }
 
 async function resolveInputOption (option) {

--- a/bin/liquid.js
+++ b/bin/liquid.js
@@ -14,7 +14,7 @@ async function render () {
   program
     .name('liquidjs')
     .description('Render a Liquid template')
-    .argument('<template>', 'liquid template to render (inline or @path to a file)')
+    .requiredOption('-t, --template <liquid | @path>', 'liquid template to render (inline or @path to a file)')
     .option('-c, --context <json | @path>', 'input context in JSON format (@- to read from stdin)')
     .option('-o, --output <path>', 'write rendered output to file (omit to write to stdout)')
     .option('--cache [size]', 'cache previously parsed template structures (default cache size: 1024)')
@@ -45,7 +45,7 @@ async function render () {
     .parse()
 
   const options = program.opts()
-  const template = await resolveTemplate(program.args[0])
+  const template = await resolveTemplate(options.template)
   const context = await resolveContext(options.context)
   const liquid = new Liquid(options)
   const output = liquid.parseAndRenderSync(template, context)

--- a/bin/liquid.js
+++ b/bin/liquid.js
@@ -3,19 +3,7 @@
 const fs = require('fs/promises')
 const Liquid = require('..').Liquid
 
-// Preserve compatibility by falling back to legacy CLI behavior if:
-// - stdin is redirected (i.e. not connected to a terminal) AND
-// - there are either no arguments, or only a single argument which does not start with a dash
-// TODO: Remove this fallback for 11.0
-
-let renderPromise = null
-if (!process.stdin.isTTY && (process.argv.length === 2 || (process.argv.length === 3 && !process.argv[2].startsWith('-')))) {
-  renderPromise = renderLegacy()
-} else {
-  renderPromise = render()
-}
-
-renderPromise.catch(err => {
+render().catch(err => {
   process.stderr.write(`${err.message}\n`)
   process.exitCode = 1
 })
@@ -26,7 +14,7 @@ async function render () {
   program
     .name('liquidjs')
     .description('Render a Liquid template')
-    .requiredOption('-t, --template <liquid | @path>', 'liquid template to render (@- to read from stdin)') // TODO: Change to argument in 11.0
+    .requiredOption('-t, --template <liquid | @path>', 'liquid template to render (inline or @path to a file)') // TODO: Change to argument in 11.0
     .option('-c, --context <json | @path>', 'input context in JSON format (@- to read from stdin)')
     .option('-o, --output <path>', 'write rendered output to file (omit to write to stdout)')
     .option('--cache [size]', 'cache previously parsed template structures (default cache size: 1024)')
@@ -58,8 +46,8 @@ async function render () {
 
   const options = program.opts()
 
-  if (Object.values(options).filter((value) => value === '@-').length > 1) {
-    throw new Error(`The stdin input specifier '@-' must only be used once.`)
+  if (options.template === '@-') {
+    throw new Error(`Reading template from stdin is not supported. Pass an inline template or @path.`)
   }
 
   const template = await resolveInputOption(options.template)
@@ -107,33 +95,4 @@ async function readStream (stream) {
     chunks.push(chunk)
   }
   return Buffer.concat(chunks).toString('utf8')
-}
-
-// TODO: Remove for 11.0
-async function renderLegacy () {
-  process.stderr.write('Reading template from stdin. This mode will be removed in next major version, use --template option instead.\n')
-  const contextArg = process.argv.slice(2)[0]
-  let context = {}
-  if (contextArg) {
-    const contextJson = await resolveInputOptionLegacy(contextArg)
-    context = JSON.parse(contextJson)
-  }
-  const template = await readStream(process.stdin)
-  const liquid = new Liquid()
-  const output = liquid.parseAndRenderSync(template, context)
-  process.stdout.write(output)
-}
-
-// TODO: Remove for 11.0
-async function resolveInputOptionLegacy (option) {
-  let content = null
-  if (option) {
-    const stat = await fs.stat(option).catch(e => null)
-    if (stat && stat.isFile) {
-      content = await fs.readFile(option, 'utf8')
-    } else {
-      content = option
-    }
-  }
-  return content
 }

--- a/bin/liquid.js
+++ b/bin/liquid.js
@@ -14,7 +14,7 @@ async function render () {
   program
     .name('liquidjs')
     .description('Render a Liquid template')
-    .requiredOption('-t, --template <liquid | @path>', 'liquid template to render (inline or @path to a file)') // TODO: Change to argument in 11.0
+    .argument('<template>', 'liquid template to render (inline or @path to a file)')
     .option('-c, --context <json | @path>', 'input context in JSON format (@- to read from stdin)')
     .option('-o, --output <path>', 'write rendered output to file (omit to write to stdout)')
     .option('--cache [size]', 'cache previously parsed template structures (default cache size: 1024)')
@@ -45,12 +45,7 @@ async function render () {
     .parse()
 
   const options = program.opts()
-
-  if (options.template === '@-') {
-    throw new Error(`Reading template from stdin is not supported. Pass an inline template or @path.`)
-  }
-
-  const template = await resolveInputOption(options.template)
+  const template = await resolveTemplate(program.args[0])
   const context = await resolveContext(options.context)
   const liquid = new Liquid(options)
   const output = liquid.parseAndRenderSync(template, context)
@@ -68,6 +63,13 @@ async function resolveContext (contextOption) {
   }
   const context = JSON.parse(contextJson)
   return context
+}
+
+async function resolveTemplate (templateOption) {
+  if (templateOption && templateOption.startsWith('@') && templateOption !== '@-') {
+    return resolveInputOption(templateOption)
+  }
+  return templateOption
 }
 
 async function resolveInputOption (option) {

--- a/docs/source/tutorials/setup.md
+++ b/docs/source/tutorials/setup.md
@@ -53,11 +53,10 @@ Pre-built UMD bundles are also available:
 
 ## LiquidJS in CLI
 
-LiquidJS can also be used to render a template directly from CLI using `npx`. Pass the template as a positional argument, or with `--template` / `-t`:
+LiquidJS can also be used to render a template directly from CLI using `npx`. Pass the template as a positional argument:
 
 ```bash
 npx liquidjs '{{"hello" | capitalize}}'
-npx liquidjs --template '{{"hello" | capitalize}}'
 ```
 
 You can either pass the template inline (as shown above), read it from a file with `@` followed by a path, or from `stdin` with `@-`:

--- a/docs/source/tutorials/setup.md
+++ b/docs/source/tutorials/setup.md
@@ -56,33 +56,33 @@ Pre-built UMD bundles are also available:
 LiquidJS can also be used to render a template directly from CLI using `npx`:
 
 ```bash
-npx liquidjs --template '{{"hello" | capitalize}}'
+npx liquidjs '{{"hello" | capitalize}}'
 ```
 
 You can either pass the template inline (as shown above) or you can read it from a file by using the `@` character followed by a path, like so:
 
 ```bash
-npx liquidjs --template @./some-template.liquid
+npx liquidjs @./some-template.liquid
 ```
 
 A context can be passed inline, from a path, or piped through `stdin`. The following three are equivalent:
 
 ```bash
-npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Snake"}'
-npx liquidjs --template 'Hello, {{ name }}!' --context @./some-context.json
-echo '{"name": "Snake"}' | npx liquidjs --template 'Hello, {{ name }}!' --context @-
+npx liquidjs 'Hello, {{ name }}!' --context '{"name": "Snake"}'
+npx liquidjs 'Hello, {{ name }}!' --context @./some-context.json
+echo '{"name": "Snake"}' | npx liquidjs 'Hello, {{ name }}!' --context @-
 ```
 
 The rendered output is written to `stdout` by default, but you can also specify an output file (if the file exists, it will be overwritten):
 
 ```bash
-npx liquidjs --template '{{"hello" | capitalize}}' --output ./hello.txt
+npx liquidjs '{{"hello" | capitalize}}' --output ./hello.txt
 ```
 
 You can also pass a number of options to customize template rendering behavior. For example, the `--js-truthy` option can be used to enable JavaScript truthiness:
 
 ```bash
-npx liquidjs --template @./some-template.liquid --js-truthy
+npx liquidjs @./some-template.liquid --js-truthy
 ```
 
 Most of the [options available through the JavaScript API][options] are also available from the CLI. For help on available options, use `npx liquidjs --help`.

--- a/docs/source/tutorials/setup.md
+++ b/docs/source/tutorials/setup.md
@@ -65,21 +65,13 @@ You can either pass the template inline (as shown above) or you can read it from
 npx liquidjs --template @./some-template.liquid
 ```
 
-You can also use the `@-` syntax to read the template from `stdin`:
-
-```bash
-echo '{{"hello" | capitalize}}' | npx liquidjs --template @-
-```
-
-A context can be passed in the same ways (i.e. inline, from a path or piped through `stdin`). The following three are equivalent:
+A context can be passed inline, from a path, or piped through `stdin`. The following three are equivalent:
 
 ```bash
 npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Snake"}'
 npx liquidjs --template 'Hello, {{ name }}!' --context @./some-context.json
 echo '{"name": "Snake"}' | npx liquidjs --template 'Hello, {{ name }}!' --context @-
 ```
-
-Note that you can only use the `stdin` specifier `@-` for a single argument. If you try to use it for both `--template` and `--context` you will get an error.
 
 The rendered output is written to `stdout` by default, but you can also specify an output file (if the file exists, it will be overwritten):
 

--- a/docs/source/tutorials/setup.md
+++ b/docs/source/tutorials/setup.md
@@ -59,19 +59,22 @@ LiquidJS can also be used to render a template directly from CLI using `npx`:
 npx liquidjs --template '{{"hello" | capitalize}}'
 ```
 
-You can either pass the template inline (as shown above) or you can read it from a file by using the `@` character followed by a path, like so:
+You can either pass the template inline (as shown above), read it from a file with `@` followed by a path, or from `stdin` with `@-`:
 
 ```bash
 npx liquidjs --template @./some-template.liquid
+echo '{{"hello" | capitalize}}' | npx liquidjs --template @-
 ```
 
-A context can be passed inline, from a path, or piped through `stdin`. The following three are equivalent:
+A context can be passed the same ways (inline, from a path, or via `@-` for `stdin`). The following three are equivalent:
 
 ```bash
 npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Snake"}'
 npx liquidjs --template 'Hello, {{ name }}!' --context @./some-context.json
 echo '{"name": "Snake"}' | npx liquidjs --template 'Hello, {{ name }}!' --context @-
 ```
+
+Note that you can only use the `stdin` specifier `@-` for a single argument. If you try to use it for both `--template` and `--context` you will get an error.
 
 The rendered output is written to `stdout` by default, but you can also specify an output file (if the file exists, it will be overwritten):
 

--- a/docs/source/tutorials/setup.md
+++ b/docs/source/tutorials/setup.md
@@ -56,33 +56,33 @@ Pre-built UMD bundles are also available:
 LiquidJS can also be used to render a template directly from CLI using `npx`:
 
 ```bash
-npx liquidjs '{{"hello" | capitalize}}'
+npx liquidjs --template '{{"hello" | capitalize}}'
 ```
 
 You can either pass the template inline (as shown above) or you can read it from a file by using the `@` character followed by a path, like so:
 
 ```bash
-npx liquidjs @./some-template.liquid
+npx liquidjs --template @./some-template.liquid
 ```
 
 A context can be passed inline, from a path, or piped through `stdin`. The following three are equivalent:
 
 ```bash
-npx liquidjs 'Hello, {{ name }}!' --context '{"name": "Snake"}'
-npx liquidjs 'Hello, {{ name }}!' --context @./some-context.json
-echo '{"name": "Snake"}' | npx liquidjs 'Hello, {{ name }}!' --context @-
+npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Snake"}'
+npx liquidjs --template 'Hello, {{ name }}!' --context @./some-context.json
+echo '{"name": "Snake"}' | npx liquidjs --template 'Hello, {{ name }}!' --context @-
 ```
 
 The rendered output is written to `stdout` by default, but you can also specify an output file (if the file exists, it will be overwritten):
 
 ```bash
-npx liquidjs '{{"hello" | capitalize}}' --output ./hello.txt
+npx liquidjs --template '{{"hello" | capitalize}}' --output ./hello.txt
 ```
 
 You can also pass a number of options to customize template rendering behavior. For example, the `--js-truthy` option can be used to enable JavaScript truthiness:
 
 ```bash
-npx liquidjs @./some-template.liquid --js-truthy
+npx liquidjs --template @./some-template.liquid --js-truthy
 ```
 
 Most of the [options available through the JavaScript API][options] are also available from the CLI. For help on available options, use `npx liquidjs --help`.

--- a/docs/source/tutorials/setup.md
+++ b/docs/source/tutorials/setup.md
@@ -53,39 +53,40 @@ Pre-built UMD bundles are also available:
 
 ## LiquidJS in CLI
 
-LiquidJS can also be used to render a template directly from CLI using `npx`:
+LiquidJS can also be used to render a template directly from CLI using `npx`. Pass the template as a positional argument, or with `--template` / `-t`:
 
 ```bash
+npx liquidjs '{{"hello" | capitalize}}'
 npx liquidjs --template '{{"hello" | capitalize}}'
 ```
 
 You can either pass the template inline (as shown above), read it from a file with `@` followed by a path, or from `stdin` with `@-`:
 
 ```bash
-npx liquidjs --template @./some-template.liquid
-echo '{{"hello" | capitalize}}' | npx liquidjs --template @-
+npx liquidjs @./some-template.liquid
+echo '{{"hello" | capitalize}}' | npx liquidjs @-
 ```
 
 A context can be passed the same ways (inline, from a path, or via `@-` for `stdin`). The following three are equivalent:
 
 ```bash
-npx liquidjs --template 'Hello, {{ name }}!' --context '{"name": "Snake"}'
-npx liquidjs --template 'Hello, {{ name }}!' --context @./some-context.json
-echo '{"name": "Snake"}' | npx liquidjs --template 'Hello, {{ name }}!' --context @-
+npx liquidjs 'Hello, {{ name }}!' --context '{"name": "Snake"}'
+npx liquidjs 'Hello, {{ name }}!' --context @./some-context.json
+echo '{"name": "Snake"}' | npx liquidjs 'Hello, {{ name }}!' --context @-
 ```
 
-Note that you can only use the `stdin` specifier `@-` for a single argument. If you try to use it for both `--template` and `--context` you will get an error.
+Note that you can only use the `stdin` specifier `@-` for a single argument. If you try to use it for both the template and `--context` you will get an error.
 
 The rendered output is written to `stdout` by default, but you can also specify an output file (if the file exists, it will be overwritten):
 
 ```bash
-npx liquidjs --template '{{"hello" | capitalize}}' --output ./hello.txt
+npx liquidjs '{{"hello" | capitalize}}' --output ./hello.txt
 ```
 
 You can also pass a number of options to customize template rendering behavior. For example, the `--js-truthy` option can be used to enable JavaScript truthiness:
 
 ```bash
-npx liquidjs --template @./some-template.liquid --js-truthy
+npx liquidjs @./some-template.liquid --js-truthy
 ```
 
 Most of the [options available through the JavaScript API][options] are also available from the CLI. For help on available options, use `npx liquidjs --help`.


### PR DESCRIPTION
## Summary
- **Breaking:** template can no longer be read from bare/default stdin. Use positional `@-`.
- **Breaking:** `--template` / `-t` removed. Template is a required positional argument only.
- `--context @-` and `@path` still work.

Fixes #940

## Test plan
- [x] `npx liquidjs '{{ hello | capitalize }}'` renders
- [x] `npx liquidjs --template '...'` fails as unknown option
- [x] `npx liquidjs @./file.liquid` reads template from file
- [x] `echo 'Hello, {{ name }}!' | npx liquidjs @- --context '{name:Snake}'` works
- [x] `echo '{name:Snake}' | npx liquidjs 'Hello, {{ name }}!' --context @-` works