### PR TITLE
feat!: restore package exports so ESM uses named exports only

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "./dist/liquid.node.js": "./dist/liquid.browser.umd.js",
     "./dist/liquid.node.mjs": "./dist/liquid.browser.mjs"
   },
+  "exports": {
+    "import": "./dist/liquid.node.mjs",
+    "require": "./dist/liquid.node.js"
+  },
   "types": "dist/index.d.ts",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- Restore `package.json` `exports` so Node ESM `import` resolves to `dist/liquid.node.mjs` (named exports only) instead of CJS interop that still allowed a fake default export
- Breaking for `import liquidjs from 'liquidjs'` under ESM; aligns with intentional removal of the default export
- Closes #941 (reverts the exports removal from #747)

## Test plan
- [ ] `npm pack` / install and verify `import { Liquid } from 'liquidjs'` resolves the ESM build
- [ ] Confirm `import liquidjs from 'liquidjs'` no longer gets a default via CJS interop
- [ ] `require('liquidjs')` still works via the `require` export condition
- [ ] CI green on this PR