### PR TITLE
feat: add unregisterFilter method

### DIFF
--- a/docs/source/tutorials/register-filters-tags.md
+++ b/docs/source/tutorials/register-filters-tags.md
@@ -70,6 +70,14 @@ engine.unregisterFilter('plus')
 
 With [`strictFilters`][strict-filters] enabled, using an unregistered filter will throw an error. Otherwise, the filter will be skipped.
 
+Built-in filters can be registered again using the exported `filters` object:
+
+```javascript
+import { filters } from 'liquidjs'
+
+engine.registerFilter('plus', filters.plus)
+```
+
 To disable a tag, or to make a disabled filter throw regardless of `strictFilters`, register a dummy implementation that throws a corresponding error (see [#324](https://github.com/harttle/liquidjs/issues/324)):
 
 ```javascript

--- a/docs/source/tutorials/register-filters-tags.md
+++ b/docs/source/tutorials/register-filters-tags.md
@@ -62,7 +62,15 @@ See existing filter implementations here: <https://github.com/harttle/liquidjs/t
 
 ## Unregister Tags/Filters
 
-In some cases it's desirable to disable some tags/filters (see [#324](https://github.com/harttle/liquidjs/issues/324)). You'll need to register a dummy tag/filter that throws a corresponding Error.
+Filters can be unregistered by name:
+
+```javascript
+engine.unregisterFilter('plus')
+```
+
+With [`strictFilters`][strict-filters] enabled, using an unregistered filter will throw an error. Otherwise, the filter will be skipped.
+
+To disable a tag, or to make a disabled filter throw regardless of `strictFilters`, register a dummy implementation that throws a corresponding error (see [#324](https://github.com/harttle/liquidjs/issues/324)):
 
 ```javascript
 // disable a tag
@@ -81,3 +89,5 @@ function disabledFilter(name) {
 }
 engine.registerFilter('plus', disabledFilter('plus'));
 ```
+
+[strict-filters]: /tutorials/options.html#strict

--- a/src/liquid.ts
+++ b/src/liquid.ts
@@ -101,6 +101,9 @@ export class Liquid {
   public registerFilter (name: string, filter: FilterImplOptions) {
     this.filters[name] = filter
   }
+  public unregisterFilter (name: string) {
+    delete this.filters[name]
+  }
   public registerTag (name: string, tag: TagClass | TagImplOptions) {
     this.tags[name] = isFunction(tag) ? tag : createTagClass(tag)
   }

--- a/test/integration/liquid/register-filters.spec.ts
+++ b/test/integration/liquid/register-filters.spec.ts
@@ -67,3 +67,33 @@ describe('liquid#registerFilter()', function () {
     await expect(new Liquid({ strictFilters: true }).parseAndRender('{{ 1 | constructor }}')).rejects.toThrow('undefined filter')
   })
 })
+
+describe('liquid#unregisterFilter()', function () {
+  let liquid: Liquid
+  beforeEach(() => { liquid = new Liquid() })
+
+  it('should unregister a custom filter', async () => {
+    liquid.registerFilter('greet', value => `hello ${value}`)
+    liquid.unregisterFilter('greet')
+    const html = await liquid.parseAndRender('{{ "world" | greet }}')
+    return expect(html).toBe('world')
+  })
+
+  it('should unregister a built-in filter', () => {
+    liquid = new Liquid({ strictFilters: true })
+    liquid.unregisterFilter('upcase')
+    return expect(liquid.parseAndRender('{{ "foo" | upcase }}')).rejects.toThrow('undefined filter: upcase')
+  })
+
+  it('should support re-registering a filter', async () => {
+    liquid.registerFilter('greet', value => `hello ${value}`)
+    liquid.unregisterFilter('greet')
+    liquid.registerFilter('greet', value => `hi ${value}`)
+    const html = await liquid.parseAndRender('{{ "world" | greet }}')
+    return expect(html).toBe('hi world')
+  })
+
+  it('should not throw for an unknown filter', () => {
+    expect(() => liquid.unregisterFilter('unknown')).not.toThrow()
+  })
+})

--- a/test/integration/liquid/register-filters.spec.ts
+++ b/test/integration/liquid/register-filters.spec.ts
@@ -1,4 +1,4 @@
-import { Liquid } from '../../../src/liquid'
+import { Liquid, filters } from '../../../src'
 
 describe('liquid#registerFilter()', function () {
   let liquid: Liquid
@@ -85,12 +85,11 @@ describe('liquid#unregisterFilter()', function () {
     return expect(liquid.parseAndRender('{{ "foo" | upcase }}')).rejects.toThrow('undefined filter: upcase')
   })
 
-  it('should support re-registering a filter', async () => {
-    liquid.registerFilter('greet', value => `hello ${value}`)
-    liquid.unregisterFilter('greet')
-    liquid.registerFilter('greet', value => `hi ${value}`)
-    const html = await liquid.parseAndRender('{{ "world" | greet }}')
-    return expect(html).toBe('hi world')
+  it('should support re-registering a built-in filter', async () => {
+    liquid.unregisterFilter('upcase')
+    liquid.registerFilter('upcase', filters.upcase)
+    const html = await liquid.parseAndRender('{{ "foo" | upcase }}')
+    return expect(html).toBe('FOO')
   })
 
   it('should not throw for an unknown filter', () => {


### PR DESCRIPTION
## Summary

- Add `Liquid#unregisterFilter(name)`
- Support removing custom and built-in filters
- Allow filters to be registered again after removal
- Document restoring built-in filters through the exported `filters` object
- Document behavior with `strictFilters`

## Motivation

This provides a supported API for removing filters without directly modifying the filter registry.

When `strictFilters` is disabled, an unregistered filter is skipped. When enabled, using it throws an undefined-filter error. Unregistering an unknown
filter is a no-op.

Built-in filters can be restored using the existing `registerFilter()` API:

```javascript
import { filters } from 'liquidjs'

engine.registerFilter('plus', filters.plus)