### PR TITLE
docs: publish .nojekyll so GitHub Pages serves underscore API pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:contributors": "node bin/build-contributors.js",
     "build:apidoc": "shx rm -rf docs/source/api && typedoc --plugin typedoc-plugin-missing-exports ./src --gitRevision master --out docs/source/api",
     "build:changelog": "node bin/build-changelog.js",
-    "build:docs-hexo": "cd docs && npm ci && npm run build && shx cp CNAME public/",
+    "build:docs-hexo": "cd docs && npm ci && npm run build && shx cp CNAME .nojekyll public/",
     "serve:docs": "cd docs && npm run start",
     "dev:docs": "run-s prepare:docs serve:docs"
   },


### PR DESCRIPTION
## Summary
- Copy `docs/.nojekyll` into `docs/public` during the Hexo docs build (alongside `CNAME`), so GitHub Pages disables Jekyll and serves TypeDoc `_internal_*` paths.
- Fixes https://github.com/harttle/liquidjs/issues/950 (production 404 for `/api/modules/_internal_.html` while local serve worked).

## Test plan
- [x] `npm run build:docs` — confirm `docs/public/.nojekyll` and `api/modules/_internal_.html` exist
- [x] Serve `docs/public` and get 200 for `/api/modules/_internal_.html`
- [ ] After merge/deploy, confirm https://liquidjs.com/api/modules/_internal_.html loads

EOF

Made with [Cursor](https://cursor.com)